### PR TITLE
Prefer ApplicationScoped to Singleton when using CDI

### DIFF
--- a/storage-blob/runtime/src/main/java/io/quarkiverse/azureservices/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
+++ b/storage-blob/runtime/src/main/java/io/quarkiverse/azureservices/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
@@ -1,12 +1,11 @@
 package io.quarkiverse.azureservices.azure.storage.blob.runtime;
 
-import javax.enterprise.inject.Default;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 
 public class StorageBlobServiceClientProducer {
 
@@ -14,8 +13,7 @@ public class StorageBlobServiceClientProducer {
     StorageBlobConfig storageBlobConfiguration;
 
     @Produces
-    @Singleton
-    @Default
+    @ApplicationScoped
     public BlobServiceClient blobServiceClient() {
         return new BlobServiceClientBuilder().connectionString(storageBlobConfiguration.connectionString).buildClient();
     }


### PR DESCRIPTION
When using CDI (which is the case of Quarkus), `@ApplicationScoped` is preferred to `@Singleton`. 
Getting rid of `@Default` as it is by default.