### PR TITLE
Rename package according to Quarkiverse naming standards

### DIFF
--- a/extensions/storage-blob/deployment/src/main/java/io/quarkiverse/azureservices/storage/blob/deployment/DevServicesConfig.java
+++ b/extensions/storage-blob/deployment/src/main/java/io/quarkiverse/azureservices/storage/blob/deployment/DevServicesConfig.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.azureservices.azure.storage.blob.deployment;
+package io.quarkiverse.azureservices.storage.blob.deployment;
 
 import java.util.Objects;
 import java.util.Optional;

--- a/extensions/storage-blob/deployment/src/main/java/io/quarkiverse/azureservices/storage/blob/deployment/DevServicesStorageBlobProcessor.java
+++ b/extensions/storage-blob/deployment/src/main/java/io/quarkiverse/azureservices/storage/blob/deployment/DevServicesStorageBlobProcessor.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.azureservices.azure.storage.blob.deployment;
+package io.quarkiverse.azureservices.storage.blob.deployment;
 
 import static io.quarkus.runtime.LaunchMode.DEVELOPMENT;
 

--- a/extensions/storage-blob/deployment/src/main/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobBuildTimeConfig.java
+++ b/extensions/storage-blob/deployment/src/main/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobBuildTimeConfig.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.azureservices.azure.storage.blob.deployment;
+package io.quarkiverse.azureservices.storage.blob.deployment;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;

--- a/extensions/storage-blob/deployment/src/main/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobProcessor.java
+++ b/extensions/storage-blob/deployment/src/main/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobProcessor.java
@@ -1,9 +1,9 @@
-package io.quarkiverse.azureservices.azure.storage.blob.deployment;
+package io.quarkiverse.azureservices.storage.blob.deployment;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
-import io.quarkiverse.azureservices.azure.storage.blob.runtime.StorageBlobServiceClientProducer;
+import io.quarkiverse.azureservices.storage.blob.runtime.StorageBlobServiceClientProducer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;

--- a/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobDevModeTest.java
+++ b/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobDevModeTest.java
@@ -1,7 +1,8 @@
-package io.quarkiverse.azureservices.azure.storage.blob.deployment;
+package io.quarkiverse.azureservices.storage.blob.deployment;
 
-import java.util.function.Supplier;
-
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.restassured.RestAssured;
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -9,9 +10,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.restassured.RestAssured;
+import java.util.function.Supplier;
 
 @QuarkusTestResource(StorageBlobTestResource.class)
 public class StorageBlobDevModeTest {

--- a/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobResource.java
+++ b/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobResource.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.azureservices.azure.storage.blob.deployment;
+package io.quarkiverse.azureservices.storage.blob.deployment;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;

--- a/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobTest.java
+++ b/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobTest.java
@@ -1,19 +1,17 @@
-package io.quarkiverse.azureservices.azure.storage.blob.deployment;
+package io.quarkiverse.azureservices.storage.blob.deployment;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-
+import com.azure.storage.blob.BlobServiceClient;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.azure.storage.blob.BlobServiceClient;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
 
-import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTestResource(StorageBlobTestResource.class)
 public class StorageBlobTest {

--- a/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobTestResource.java
+++ b/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobTestResource.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.azureservices.azure.storage.blob.deployment;
+package io.quarkiverse.azureservices.storage.blob.deployment;
 
 import java.util.Map;
 

--- a/extensions/storage-blob/runtime/src/main/java/io/quarkiverse/azureservices/storage/blob/runtime/StorageBlobConfig.java
+++ b/extensions/storage-blob/runtime/src/main/java/io/quarkiverse/azureservices/storage/blob/runtime/StorageBlobConfig.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.azureservices.azure.storage.blob.runtime;
+package io.quarkiverse.azureservices.storage.blob.runtime;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;

--- a/extensions/storage-blob/runtime/src/main/java/io/quarkiverse/azureservices/storage/blob/runtime/StorageBlobServiceClientProducer.java
+++ b/extensions/storage-blob/runtime/src/main/java/io/quarkiverse/azureservices/storage/blob/runtime/StorageBlobServiceClientProducer.java
@@ -1,10 +1,10 @@
-package io.quarkiverse.azureservices.azure.storage.blob.runtime;
-
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
+package io.quarkiverse.azureservices.storage.blob.runtime;
 
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 
 public class StorageBlobServiceClientProducer {
 

--- a/integration-tests/src/main/java/io/quarkiverse/azureservices/storage/blob/it/StorageBlobResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/azureservices/storage/blob/it/StorageBlobResource.java
@@ -14,17 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.quarkiverse.azureservices.azure.storage.blob.it;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
+package io.quarkiverse.azureservices.storage.blob.it;
 
 import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 
 @Path("/azure-storage-blob")
 @ApplicationScoped

--- a/integration-tests/src/test/java/io/quarkiverse/azureservices/storage/blob/it/StorageBlobResourceIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/azureservices/storage/blob/it/StorageBlobResourceIT.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.azureservices.azure.storage.blob.it;
+package io.quarkiverse.azureservices.storage.blob.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/integration-tests/src/test/java/io/quarkiverse/azureservices/storage/blob/it/StorageBlobResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/azureservices/storage/blob/it/StorageBlobResourceTest.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.azureservices.azure.storage.blob.it;
+package io.quarkiverse.azureservices.storage.blob.it;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;


### PR DESCRIPTION
I renamed the packages `io.quarkiverse.azureservices.azure.*` to `io.quarkiverse.azureservices.*` according to the Quarkiverse naming conventions. This way we avoid the duplication `azureservices.azure`.

@majguo we could also rename our packages `io.quarkiverse.azure.*` instead of having `azureservices`. It would also fit better with the configuration keys that are called `quarkus.azure`. WDYT?