### PR TITLE
Removes all Camel package name

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/azureservices/core/deployment/AzureCoreSupportProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/azureservices/core/deployment/AzureCoreSupportProcessor.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.support.reactor.netty.deployment;
+package io.quarkiverse.azureservices.core.deployment;
 
 import java.io.IOException;
 import java.util.Set;

--- a/extensions/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -16,12 +16,12 @@
 #
 
 ---
-name: "Camel Quarkus Support Azure Core"
-description: "Camel Quarkus Support Azure Core"
+name: "Quarkus Support Azure Core"
+description: "Quarkus Support Azure Core"
 metadata:
   unlisted: true
   keywords:
-  - "camel"
-  guide: "https://quarkus.io/guides/camel"
+  - "azure"
+  guide: "https://quarkus.io/guides/deploying-to-azure-cloud"
   categories:
   - "integration"

--- a/extensions/http-client-vertx/deployment/src/main/java/io/quarkiverse/azureservices/core/http/vertx/deployment/AzureCoreHttpClientVertxProcessor.java
+++ b/extensions/http-client-vertx/deployment/src/main/java/io/quarkiverse/azureservices/core/http/vertx/deployment/AzureCoreHttpClientVertxProcessor.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.support.azure.core.http.vertx;
+package io.quarkiverse.azureservices.core.http.vertx.deployment;
 
 import com.azure.core.http.vertx.VertxProvider;
 

--- a/extensions/http-client-vertx/runtime/src/main/java/io/quarkiverse/azureservices/core/http/vertx/runtime/QuarkusVertxProvider.java
+++ b/extensions/http-client-vertx/runtime/src/main/java/io/quarkiverse/azureservices/core/http/vertx/runtime/QuarkusVertxProvider.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.support.azure.core.http.vertx;
+package io.quarkiverse.azureservices.core.http.vertx.runtime;
 
 import java.util.Set;
 

--- a/extensions/http-client-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/http-client-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -16,12 +16,12 @@
 #
 
 ---
-name: "Camel Quarkus Support Azure Core HTTP Client Vert.x"
-description: "Camel Quarkus Support Azure Core HTTP Client Vert.x"
+name: "Quarkus Support Azure Core HTTP Client Vert.x"
+description: "Quarkus Support Azure Core HTTP Client Vert.x"
 metadata:
   unlisted: true
   keywords:
-    - "camel"
-  guide: "https://quarkus.io/guides/camel"
+    - "azure"
+  guide: "https://quarkus.io/guides/deploying-to-azure-cloud"
   categories:
     - "integration"

--- a/extensions/http-client-vertx/runtime/src/main/resources/META-INF/services/com.azure.core.http.vertx.VertxProvider
+++ b/extensions/http-client-vertx/runtime/src/main/resources/META-INF/services/com.azure.core.http.vertx.VertxProvider
@@ -1,1 +1,1 @@
-org.apache.camel.quarkus.support.azure.core.http.vertx.QuarkusVertxProvider
+io.quarkiverse.azureservices.core.http.vertx.runtime.QuarkusVertxProvider

--- a/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobDevModeTest.java
+++ b/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobDevModeTest.java
@@ -1,8 +1,7 @@
 package io.quarkiverse.azureservices.storage.blob.deployment;
 
-import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.restassured.RestAssured;
+import java.util.function.Supplier;
+
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -10,7 +9,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.util.function.Supplier;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.restassured.RestAssured;
 
 @QuarkusTestResource(StorageBlobTestResource.class)
 public class StorageBlobDevModeTest {

--- a/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobTest.java
+++ b/extensions/storage-blob/deployment/src/test/java/io/quarkiverse/azureservices/storage/blob/deployment/StorageBlobTest.java
@@ -1,17 +1,19 @@
 package io.quarkiverse.azureservices.storage.blob.deployment;
 
-import com.azure.storage.blob.BlobServiceClient;
-import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
+import com.azure.storage.blob.BlobServiceClient;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
 
 @QuarkusTestResource(StorageBlobTestResource.class)
 public class StorageBlobTest {

--- a/extensions/storage-blob/runtime/src/main/java/io/quarkiverse/azureservices/storage/blob/runtime/StorageBlobServiceClientProducer.java
+++ b/extensions/storage-blob/runtime/src/main/java/io/quarkiverse/azureservices/storage/blob/runtime/StorageBlobServiceClientProducer.java
@@ -1,10 +1,10 @@
 package io.quarkiverse.azureservices.storage.blob.runtime;
 
-import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.BlobServiceClientBuilder;
-
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
+
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
 
 public class StorageBlobServiceClientProducer {
 

--- a/integration-tests/src/main/java/io/quarkiverse/azureservices/storage/blob/it/StorageBlobResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/azureservices/storage/blob/it/StorageBlobResource.java
@@ -16,15 +16,15 @@
  */
 package io.quarkiverse.azureservices.storage.blob.it;
 
-import com.azure.core.util.BinaryData;
-import com.azure.storage.blob.BlobClient;
-import com.azure.storage.blob.BlobContainerClient;
-import com.azure.storage.blob.BlobServiceClient;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+
+import com.azure.core.util.BinaryData;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
 
 @Path("/azure-storage-blob")
 @ApplicationScoped


### PR DESCRIPTION
The code that the Camel team contributed, still had the `camel` package name. This gets rid of them