### PR TITLE
Simplify app-configuration tests

### DIFF
--- a/extensions/app-configuration/deployment/src/main/java/io/quarkiverse/azure/app/configuration/deployment/AzureAppConfigurationProcessor.java
+++ b/extensions/app-configuration/deployment/src/main/java/io/quarkiverse/azure/app/configuration/deployment/AzureAppConfigurationProcessor.java
@@ -13,7 +13,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
 public class AzureAppConfigurationProcessor {
     @BuildStep
@@ -33,7 +32,6 @@ public class AzureAppConfigurationProcessor {
 
     @BuildStep
     void nativeImage(
-            BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClasses,
             BuildProducer<NativeImageProxyDefinitionBuildItem> nativeImageProxyDefinitions,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
 

--- a/extensions/app-configuration/deployment/src/test/java/io/quarkiverse/azure/app/configuration/deployment/AzureAppConfigurationResource.java
+++ b/extensions/app-configuration/deployment/src/test/java/io/quarkiverse/azure/app/configuration/deployment/AzureAppConfigurationResource.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
@@ -20,8 +19,9 @@ public class AzureAppConfigurationResource implements QuarkusTestResourceLifecyc
 
     @Override
     public Map<String, String> start() {
+        int port = 8082;
         try {
-            httpServer = HttpServer.create(new InetSocketAddress(8082), 0);
+            httpServer = HttpServer.create(new InetSocketAddress(port), 0);
             httpServer.createContext("/kv", new HttpHandler() {
                 @Override
                 public void handle(final HttpExchange exchange) throws IOException {
@@ -45,7 +45,12 @@ public class AzureAppConfigurationResource implements QuarkusTestResourceLifecyc
             throw new RuntimeException(e);
         }
 
-        return Collections.emptyMap();
+        return Map.of(
+                "quarkus.azure.app.configuration.endpoint", "http://localhost:" + port,
+                /* Our server does not validate the credentials anyway */
+                "quarkus.azure.app.configuration.id", "dummy",
+                "quarkus.azure.app.configuration.secret", "aGVsbG8=" // Base64 encoded "hello"
+        );
     }
 
     @Override

--- a/extensions/app-configuration/deployment/src/test/java/io/quarkiverse/azure/app/configuration/deployment/AzureAppConfigurationTest.java
+++ b/extensions/app-configuration/deployment/src/test/java/io/quarkiverse/azure/app/configuration/deployment/AzureAppConfigurationTest.java
@@ -17,10 +17,7 @@ import io.smallrye.config.SmallRyeConfig;
 class AzureAppConfigurationTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
-            .overrideConfigKey("quarkus.azure.app.configuration.endpoint", "http://localhost:8082")
-            .overrideConfigKey("quarkus.azure.app.configuration.id", "dummy")
-            .overrideConfigKey("quarkus.azure.app.configuration.secret", "aGVsbG8=");
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Inject
     SmallRyeConfig config;

--- a/extensions/app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
+++ b/extensions/app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
@@ -1,7 +1,7 @@
 package io.quarkiverse.azure.app.configuration;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -44,7 +44,7 @@ public class AzureAppConfigurationConfigSourceFactory
 
         ConfigurationClient client = clientBuilder.buildClient();
 
-        Map<String, String> properties = new HashMap<>();
+        Map<String, String> properties = new LinkedHashMap<>(); // LinkedHashMap for reproducible ordering
         PagedIterable<ConfigurationSetting> listConfigurationSettings = client.listConfigurationSettings(new SettingSelector());
         listConfigurationSettings.forEach(new Consumer<ConfigurationSetting>() {
             @Override

--- a/integration-tests/app-configuration/pom.xml
+++ b/integration-tests/app-configuration/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkiverse.azureservices</groupId>
             <artifactId>quarkus-azure-app-configuration</artifactId>
         </dependency>

--- a/integration-tests/app-configuration/src/main/java/io/quarkiverse/azure/app/configuration/it/ConfigResource.java
+++ b/integration-tests/app-configuration/src/main/java/io/quarkiverse/azure/app/configuration/it/ConfigResource.java
@@ -6,9 +6,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.config.SmallRyeConfig;
 
 @Path("/config")
@@ -19,15 +17,8 @@ public class ConfigResource {
 
     @GET
     @Path("/{name}")
-    public Response configValue(@PathParam("name") final String name) {
-        return Response.ok(config.getConfigValue(name)).build();
+    public String configValue(@PathParam("name") final String name) {
+        return config.getConfigValue(name).getValue();
     }
 
-    @RegisterForReflection(targets = {
-            org.eclipse.microprofile.config.ConfigValue.class,
-            io.smallrye.config.ConfigValue.class
-    })
-    public static class ConfigValueReflection {
-
-    }
 }

--- a/integration-tests/app-configuration/src/main/resources/application.properties
+++ b/integration-tests/app-configuration/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-quarkus.azure.app.configuration.endpoint=http://localhost:8082
-quarkus.azure.app.configuration.id=dummy
-quarkus.azure.app.configuration.secret=aGVsbG8=

--- a/integration-tests/app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationResource.java
+++ b/integration-tests/app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationResource.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
@@ -20,8 +19,9 @@ public class AzureAppConfigurationResource implements QuarkusTestResourceLifecyc
 
     @Override
     public Map<String, String> start() {
+        int port = 8082;
         try {
-            httpServer = HttpServer.create(new InetSocketAddress(8082), 0);
+            httpServer = HttpServer.create(new InetSocketAddress(port), 0);
             httpServer.createContext("/kv", new HttpHandler() {
                 @Override
                 public void handle(final HttpExchange exchange) throws IOException {
@@ -45,7 +45,12 @@ public class AzureAppConfigurationResource implements QuarkusTestResourceLifecyc
             throw new RuntimeException(e);
         }
 
-        return Collections.emptyMap();
+        return Map.of(
+                "quarkus.azure.app.configuration.endpoint", "http://localhost:" + port,
+                /* Our server does not validate the credentials anyway */
+                "quarkus.azure.app.configuration.id", "dummy",
+                "quarkus.azure.app.configuration.secret", "aGVsbG8=" // Base64 encoded "hello"
+        );
     }
 
     @Override

--- a/integration-tests/app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationTest.java
+++ b/integration-tests/app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationTest.java
@@ -18,12 +18,12 @@ class AzureAppConfigurationTest {
                 .get("/config/{name}", "my.prop")
                 .then()
                 .statusCode(OK.getStatusCode())
-                .body("value", equalTo("1234"));
+                .body(equalTo("1234"));
 
         given()
                 .get("/config/{name}", "another.prop")
                 .then()
                 .statusCode(OK.getStatusCode())
-                .body("value", equalTo("5678"));
+                .body(equalTo("5678"));
     }
 }


### PR DESCRIPTION
Could you please review @radcortez ?

I still wonder why the test application outputs these warnings?

```
[INFO] 2022-12-06 22:56:05,053 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.azure.app.configuration.secret" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
[INFO] 2022-12-06 22:56:05,055 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.azure.app.configuration.id" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
[INFO] 2022-12-06 22:56:05,056 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.azure.app.configuration.endpoint" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```