### PR TITLE
Remove superfluous io.netty:netty-tcnative BOM entry

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -44,11 +44,6 @@
                 <artifactId>azure-core-http-vertx</artifactId>
                 <version>${azure.core.http.client.vertx.version}</version>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative</artifactId>
-                <version>${netty.tcnative.version}</version>
-            </dependency>
 
             <!-- Azure Services Extensions -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
 
         <azure.core.http.client.vertx.version>1.0.0-beta.3</azure.core.http.client.vertx.version>
         <msal4j.version>1.13.3</msal4j.version><!-- @sync com.azure:azure-identity:${azure-identity.version} dep:com.microsoft.azure:msal4j -->
-        <netty.tcnative.version>2.0.55.Final</netty.tcnative.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
https://github.com/quarkiverse/quarkus-azure-services/pull/53 hit my eyes due to upgrading to netty 2.0.55 that is different from what is Quarkus 2.15.3 using (2.0.54). Investigating further has shown that io.netty:netty-tcnative should not be needed at all. So let's remove it.