### PR TITLE
Bump azurite to 3.23.0

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-azure-storage-blob.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-storage-blob.adoc
@@ -56,7 +56,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_AZURE_STORAGE_BLOB_DEVSERVICES_IMAGE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --|string 
-|`mcr.microsoft.com/azure-storage/azurite:3.21.0`
+|`mcr.microsoft.com/azure-storage/azurite:3.23.0`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-azure-storage-blob_quarkus.azure.storage.blob.devservices.port]]`link:#quarkus-azure-storage-blob_quarkus.azure.storage.blob.devservices.port[quarkus.azure.storage.blob.devservices.port]`

--- a/extensions/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/DevServicesStorageBlobProcessor.java
+++ b/extensions/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/DevServicesStorageBlobProcessor.java
@@ -32,7 +32,7 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 
 public class DevServicesStorageBlobProcessor {
 
-    static final String IMAGE = "mcr.microsoft.com/azure-storage/azurite:3.21.0";
+    static final String IMAGE = "mcr.microsoft.com/azure-storage/azurite:3.23.0";
     private static final Logger log = Logger.getLogger(DevServicesStorageBlobProcessor.class);
     private static final int EXPOSED_PORT = 10000;
     private static final String PROTOCOL = "http";

--- a/extensions/azure-storage-blob/deployment/src/test/java/io/quarkiverse/azure/storage/blob/deployment/StorageBlobTestResource.java
+++ b/extensions/azure-storage-blob/deployment/src/test/java/io/quarkiverse/azure/storage/blob/deployment/StorageBlobTestResource.java
@@ -11,7 +11,7 @@ public class StorageBlobTestResource implements QuarkusTestResourceLifecycleMana
 
     static String accountName = "devstoreaccount1";
     static String accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
-    static String image = "mcr.microsoft.com/azure-storage/azurite:3.21.0";
+    static String image = "mcr.microsoft.com/azure-storage/azurite:3.23.0";
     static int port = 10000;
     static String protocol = "http";
 


### PR DESCRIPTION
Bump azurite to `3.23.0` to support Azure Storage API Version `2022-11-02`, see https://github.com/Azure/Azurite.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>