### PR TITLE
Bump azure sdk to 1.2.13

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <azure-sdk-bom.version>1.2.12</azure-sdk-bom.version>
+        <azure-sdk-bom.version>1.2.13</azure-sdk-bom.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Bump `azure-sdk-bom` to `1.2.13`.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>