### PR TITLE
Replace 'new ReflectiveClassBuildItem()' with 'ReflectiveClassBuildItem.builder()'

### DIFF
--- a/extensions/azure-app-configuration/deployment/src/main/java/io/quarkiverse/azure/app/configuration/deployment/AzureAppConfigurationProcessor.java
+++ b/extensions/azure-app-configuration/deployment/src/main/java/io/quarkiverse/azure/app/configuration/deployment/AzureAppConfigurationProcessor.java
@@ -38,8 +38,8 @@ public class AzureAppConfigurationProcessor {
         nativeImageProxyDefinitions.produce(new NativeImageProxyDefinitionBuildItem(
                 List.of("com.azure.data.appconfiguration.implementation.ConfigurationClientImpl$ConfigurationService")));
 
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, true,
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
                 ConfigurationSettingPage.class,
-                ConfigurationSetting.class));
+                ConfigurationSetting.class).fields().build());
     }
 }

--- a/extensions/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/StorageBlobProcessor.java
+++ b/extensions/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/StorageBlobProcessor.java
@@ -49,7 +49,7 @@ class StorageBlobProcessor {
                         || n.startsWith("com.azure.storage.blob.models."))
                 .sorted()
                 .toArray(String[]::new);
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, true, modelClasses));
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(modelClasses).fields().build());
     }
 
 }

--- a/internal/core/deployment/src/main/java/io/quarkiverse/azure/core/deployment/AzureCoreSupportProcessor.java
+++ b/internal/core/deployment/src/main/java/io/quarkiverse/azure/core/deployment/AzureCoreSupportProcessor.java
@@ -58,15 +58,15 @@ public class AzureCoreSupportProcessor {
 
     @BuildStep
     void reflectiveClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false,
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
                 com.azure.core.util.DateTimeRfc1123.class,
                 com.azure.core.http.rest.StreamResponse.class,
                 com.azure.core.http.rest.ResponseBase.class,
-                com.azure.core.http.HttpHeaderName.class));
+                com.azure.core.http.HttpHeaderName.class).build());
 
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, true,
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
                 "com.microsoft.aad.msal4j.AadInstanceDiscoveryResponse",
-                "com.microsoft.aad.msal4j.InstanceDiscoveryMetadataEntry"));
+                "com.microsoft.aad.msal4j.InstanceDiscoveryMetadataEntry").fields().build());
 
     }
 


### PR DESCRIPTION
The PR is to fix the warning `ReflectiveClassBuildItem has been deprecated and marked for removal`, by replacing 'new ReflectiveClassBuildItem()' with 'ReflectiveClassBuildItem.builder()'.

The code changes reference the fix of following issues:
* https://github.com/apache/camel-quarkus/issues/4635
* https://github.com/apache/camel-quarkus/issues/4694

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>