### PR TITLE
Set up integration tests to run against the real Azure services

### DIFF
--- a/.github/build-with-maven-native.sh
+++ b/.github/build-with-maven-native.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# The following environment variables need to be configured before running the script
+# - RESOURCE_GROUP_NAME
+# - STORAGE_ACCOUNT_NAME
+
+# Create a resource group
+az group create \
+    --name "${RESOURCE_GROUP_NAME}" \
+    --location eastus
+
+# Create a storage account
+az storage account create \
+    --name "${STORAGE_ACCOUNT_NAME}" \
+    --resource-group "${RESOURCE_GROUP_NAME}" \
+    --location eastus \
+    --sku Standard_LRS \
+    --kind StorageV2
+
+# Retrieve the connection string for the storage account and export it as an environment variable
+export QUARKUS_AZURE_STORAGE_BLOB_CONNECTION_STRING=$(az storage account show-connection-string \
+  --resource-group "${RESOURCE_GROUP_NAME}" \
+  --name "${STORAGE_ACCOUNT_NAME}" \
+  --query connectionString -o tsv)
+
+# Build native executable and run the integration tests against the Azure services
+mvn -B install -Dnative -Dquarkus.native.container-build
+
+# Delete the resource group
+az group delete \
+    --name "${RESOURCE_GROUP_NAME}" \
+    --yes --no-wait

--- a/.github/build-with-maven-native.sh
+++ b/.github/build-with-maven-native.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 # The following environment variables need to be configured before running the script
 # - RESOURCE_GROUP_NAME
 # - STORAGE_ACCOUNT_NAME
+# - APP_CONFIG_NAME
 
 # Create a resource group
 az group create \
@@ -18,14 +19,44 @@ az storage account create \
     --sku Standard_LRS \
     --kind StorageV2
 
-# Retrieve the connection string for the storage account and export it as an environment variable
+# Retrieve the connection string for the storage account and export as an environment variable
 export QUARKUS_AZURE_STORAGE_BLOB_CONNECTION_STRING=$(az storage account show-connection-string \
   --resource-group "${RESOURCE_GROUP_NAME}" \
   --name "${STORAGE_ACCOUNT_NAME}" \
   --query connectionString -o tsv)
 
+# Create an app configuration store
+az appconfig create \
+    --name "${APP_CONFIG_NAME}" \
+    --resource-group "${RESOURCE_GROUP_NAME}" \
+    --location eastus
+
+# Add a few key-value pairs to the app configuration store
+az appconfig kv set \
+    --name "${APP_CONFIG_NAME}" \
+    --key my.prop \
+    --value 1234 \
+    --yes
+az appconfig kv set \
+    --name "${APP_CONFIG_NAME}" \
+    --key another.prop \
+    --value 5678 \
+    --yes
+
+# Retrieve the connection info for the app configuration store and export as environment variables
+export QUARKUS_AZURE_APP_CONFIGURATION_ENDPOINT=$(az appconfig show \
+  --resource-group "${RESOURCE_GROUP_NAME}" \
+  --name "${APP_CONFIG_NAME}" \
+  --query endpoint -o tsv)
+credential=$(az appconfig credential list \
+    --name "${APP_CONFIG_NAME}" \
+    --resource-group "${RESOURCE_GROUP_NAME}" \
+    | jq 'map(select(.readOnly == true)) | .[0]')
+export QUARKUS_AZURE_APP_CONFIGURATION_ID=$(echo "${credential}" | jq -r '.id')
+export QUARKUS_AZURE_APP_CONFIGURATION_SECRET=$(echo "${credential}" | jq -r '.value')
+
 # Build native executable and run the integration tests against the Azure services
-mvn -B install -Dnative -Dquarkus.native.container-build
+mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip -Dazure.test=true
 
 # Delete the resource group
 az group delete \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,22 @@ defaults:
   run:
     shell: bash
 
+# In order to run tests against the real Azure services, AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID need to be configured as secrets in a GitHub environment "ci" to enable OIDC authentication with Azure.
+# See https://aka.ms/config-federated-identity-on-uami for more information on how to configure federated identity credential on a user-assigned managed identity (uami) and retrieve values for these required GitHub secrets.
+# Besides, the uami needs to be granted the "Contributor" role on the subscription to deploy and delete Azure resources for testing.
+
+env:
+  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  RESOURCE_GROUP_NAME: quarkus${{ github.run_id }}${{ github.run_number }}
+  STORAGE_ACCOUNT_NAME: storage${{ github.run_id }}${{ github.run_number }}
+
 jobs:
   build:
+    permissions:
+      id-token: write
+    environment: ci
     name: Build on ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -57,6 +71,19 @@ jobs:
 
       - name: Build with Maven (Native)
         run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip
+        if: ${{ env.AZURE_CLIENT_ID == '' || env.AZURE_TENANT_ID == '' || env.AZURE_SUBSCRIPTION_ID == '' }}
+
+      - name: Az CLI login
+        uses: azure/login@v1
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+        if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' }}
+
+      - name: Build with Maven (Native) and run tests against Azure services
+        run: .github/build-with-maven-native.sh
+        if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' }}
 
       - name: Fail if there are uncommitted changes
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ defaults:
   run:
     shell: bash
 
-# In order to run tests against the real Azure services, you need to create a GitHub environment "ci" and add AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID as its secrets to enable OIDC authentication with Azure.
-# See https://aka.ms/config-federated-identity-on-uami for more information on how to configure federated identity credential on a user-assigned managed identity (uami) and retrieve values for these required GitHub secrets.
+# In order to run tests against the real Azure services, you need to create a GitHub environment "ci" and add AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID as its variables to enable OIDC authentication with Azure.
+# See https://aka.ms/config-federated-identity-on-uami for more information on how to configure federated identity credential on a user-assigned managed identity (uami) and retrieve values for these required GitHub variables.
 # Besides, the uami needs to be granted the "Contributor" role on the subscription to deploy and delete Azure resources for testing.
 
 jobs:
@@ -40,9 +40,9 @@ jobs:
       id-token: write
     environment: ci
     env:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       RESOURCE_GROUP_NAME: quarkus${{ github.run_id }}${{ github.run_number }}
       STORAGE_ACCOUNT_NAME: storage${{ github.run_id }}${{ github.run_number }}
       APP_CONFIG_NAME: appconfig${{ github.run_id }}${{ github.run_number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,22 +30,22 @@ defaults:
   run:
     shell: bash
 
-# In order to run tests against the real Azure services, AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID need to be configured as secrets in a GitHub environment "ci" to enable OIDC authentication with Azure.
+# In order to run tests against the real Azure services, you need to create a GitHub environment "ci" and add AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID as its secrets to enable OIDC authentication with Azure.
 # See https://aka.ms/config-federated-identity-on-uami for more information on how to configure federated identity credential on a user-assigned managed identity (uami) and retrieve values for these required GitHub secrets.
 # Besides, the uami needs to be granted the "Contributor" role on the subscription to deploy and delete Azure resources for testing.
-
-env:
-  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  RESOURCE_GROUP_NAME: quarkus${{ github.run_id }}${{ github.run_number }}
-  STORAGE_ACCOUNT_NAME: storage${{ github.run_id }}${{ github.run_number }}
 
 jobs:
   build:
     permissions:
       id-token: write
     environment: ci
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      RESOURCE_GROUP_NAME: quarkus${{ github.run_id }}${{ github.run_number }}
+      STORAGE_ACCOUNT_NAME: storage${{ github.run_id }}${{ github.run_number }}
+      APP_CONFIG_NAME: appconfig${{ github.run_id }}${{ github.run_number }}
     name: Build on ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -26,8 +26,22 @@ defaults:
   run:
     shell: bash
 
+# In order to run tests against the real Azure services, you need to create a GitHub environment "ci" and add AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID as its variables to enable OIDC authentication with Azure.
+# See https://aka.ms/config-federated-identity-on-uami for more information on how to configure federated identity credential on a user-assigned managed identity (uami) and retrieve values for these required GitHub variables.
+# Besides, the uami needs to be granted the "Contributor" role on the subscription to deploy and delete Azure resources for testing.
+
 jobs:
   build:
+    permissions:
+      id-token: write
+    environment: ci
+    env:
+      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      RESOURCE_GROUP_NAME: quarkus${{ github.run_id }}${{ github.run_number }}
+      STORAGE_ACCOUNT_NAME: storage${{ github.run_id }}${{ github.run_number }}
+      APP_CONFIG_NAME: appconfig${{ github.run_id }}${{ github.run_number }}
     name: "Build against latest Quarkus snapshot"
     runs-on: ubuntu-latest
     # Allow <ADMIN> to manually launch the ecosystem CI in addition to the bots
@@ -58,3 +72,17 @@ jobs:
         run: ./ecosystem-ci/setup-and-test
         env:
           ECOSYSTEM_CI_TOKEN: ${{ secrets.ECOSYSTEM_CI_TOKEN }}
+
+      - name: Az CLI login
+        uses: azure/login@v1
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+        if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' }}
+
+      - name: Build with Maven (Native) and run tests against Azure services
+        run: |
+          cd ${GITHUB_WORKSPACE}/current-repo/integration-tests
+          ../.github/build-with-maven-native.sh
+        if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' }}

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -31,7 +31,8 @@ az group create \
 
 ### Creating Azure Storage Account
 
-Run the following commands to create an Azure Storage Account and retrieve its connection string:
+Run the following commands to create an Azure Storage Account and export its connection string as an environment
+variable.
 
 ```
 STORAGE_ACCOUNT_NAME=<unique-storage-account-name>
@@ -42,26 +43,27 @@ az storage account create \
     --sku Standard_LRS \
     --kind StorageV2
 
-STORAGE_ACCOUNT_CONNECTION_STRING=$(az storage account show-connection-string \
+export QUARKUS_AZURE_STORAGE_BLOB_CONNECTION_STRING=$(az storage account show-connection-string \
     --resource-group ${RESOURCE_GROUP_NAME} \
     --name ${STORAGE_ACCOUNT_NAME} \
     --query connectionString -o tsv)
-echo "The value of 'quarkus.azure.storage.blob.connection-string' is: ${STORAGE_ACCOUNT_CONNECTION_STRING}"
+echo "The value of 'quarkus.azure.storage.blob.connection-string' is: ${QUARKUS_AZURE_STORAGE_BLOB_CONNECTION_STRING}"
 ```
 
+The value of environment variable `QUARKUS_AZURE_STORAGE_BLOB_CONNECTION_STRING` will be fed into config
+property `quarkus.azure.storage.blob.connection-string` of `azure-storage-blob` extension in order to set up the
+connection to the Azure Storage Account.
+
+You can also manually copy the output of the variable `quarkus.azure.storage.blob.connection-string` and then
+update [application.properties](azure-storage-blob/src/main/resources/application.properties) by uncommenting the
+same property and setting copied value.
+
 ### Running the test
-
-Copy the output of the following variables from previous steps:
-
-* **quarkus.azure.storage.blob.connection-string**
-
-Then update [application.properties](src/main/resources/application.properties) by uncommenting the relevant properties
-and setting copied values.
 
 Finally, build the native executable and launch the test with:
 
 ```
-mvn integration-test -Dnative
+mvn integration-test -Dnative -Dquarkus.native.container-build
 ```
 
 ### Cleaning up Azure resources

--- a/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationExternalIT.java
+++ b/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationExternalIT.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.azure.app.configuration.it;
+
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusIntegrationTest
+@TestProfile(AzureAppConfigurationExternalIT.TestProfile.class)
+@EnabledIfSystemProperty(named = "azure.test", matches = "true")
+public class AzureAppConfigurationExternalIT extends AzureAppConfigurationTest {
+    public static class TestProfile implements QuarkusTestProfile {
+        public boolean disableGlobalTestResources() {
+            return true;
+        }
+    }
+}

--- a/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationIT.java
+++ b/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationIT.java
@@ -1,8 +1,11 @@
 package io.quarkiverse.azure.app.configuration.it;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
+@DisabledIfSystemProperty(named = "azure.test", matches = "true")
 public class AzureAppConfigurationIT extends AzureAppConfigurationTest {
 
 }

--- a/integration-tests/azure-storage-blob/src/main/java/io/quarkiverse/azure/storage/blob/it/StorageBlobResource.java
+++ b/integration-tests/azure-storage-blob/src/main/java/io/quarkiverse/azure/storage/blob/it/StorageBlobResource.java
@@ -22,13 +22,7 @@ import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -92,9 +86,9 @@ public class StorageBlobResource {
     @Path("/{container}")
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public String listBlobs() {
+    public String listBlobs(@PathParam("container") String container) {
         BlobContainerClient blobContainerClient = blobServiceClient
-                .createBlobContainerIfNotExists("container-quarkus-azure-storage-blob");
+                .createBlobContainerIfNotExists(container);
         return blobContainerClient.listBlobs().stream()
                 .map(BlobItem::getName)
                 .collect(Collectors.joining(","));

--- a/integration-tests/azure-storage-blob/src/main/resources/application.properties
+++ b/integration-tests/azure-storage-blob/src/main/resources/application.properties
@@ -1,6 +1,2 @@
-# Uncomment if you dont want to use the default DevServices
-quarkus.azure.storage.blob.health.enabled=true
-quarkus.azure.storage.blob.devservices.enabled=true
-
 # Uncomment and set a valid connection string of an Azure Storage Account if you want to connect Azure. Otherwise, leave it to use Dev Services of Azure Storage Blob extension for development and testing purpose.
 #quarkus.azure.storage.blob.connection-string=


### PR DESCRIPTION
The PR is to resolve #37 by setting up the integration tests against the real Azure services,
* if OICD authentication is enabled in `Build` / `Quarkus ecosystem CI` workflow
* Otherwise run integration tests against mocked Azure services (DevServices or mocked http server) 

## Testing

Here're two successful runs of `Build` workflow in my fork:
* [run integration tests against real Azure services](https://github.com/majguo/quarkus-azure-services/actions/runs/5150977028)
* [run integration tests against mocked Azure services](https://github.com/majguo/quarkus-azure-services/actions/runs/5150281096)

## ~~TODOs~~

~~I have already configured a federated identity credential on a user-assigned managed identity (see https://aka.ms/config-federated-identity-on-uami). In order to run tests against the real Azure services, the following actions are required:~~
* ~~Create a GitHub environment **ci** in https://github.com/quarkiverse/quarkus-azure-services~~
* ~~Add `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` as secrets of environment "ci".~~

~~Since I don't have permission to create GitHub environment/secrets in https://github.com/quarkiverse/quarkus-azure-services, I need help on these TODOs, talk to @majguo for these secrets' values. @gastaldi @ppalaga @gsmet.~~

## **NOTE**: TODOs are completed with help from @gastaldi. They're configured as Environment Variables (instead of Environment Secrets).


Signed-off-by: Jianguo Ma <jiangma@microsoft.com>