### PR TITLE
Fix malformed metadata in extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quarkiverse - Quarkus Azure Services
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This repository hosts Quarkus extensions for different Azure Services. You can check the [documentation of these services](https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/index.html).

--- a/extensions/azure-app-configuration/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-app-configuration/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,6 @@
 ---
 name: "Quarkus Azure App Configuration"
+description: "Quarkus Azure App Configuration"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   short-name: "azure-app-configuration"

--- a/extensions/azure-app-configuration/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-app-configuration/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,4 +12,5 @@ metadata:
   categories:
     - "cloud"
   status: "preview"
-  config: "quarkus.azure.app.configuration"
+  config: 
+    - "quarkus.azure.app.configuration."

--- a/extensions/azure-storage-blob/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-storage-blob/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,14 +1,16 @@
+---
 name: "Quarkus Support Azure Storage Blob"
-description: "Quarkus Support for Azure Storage Blob"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   short-name: "azure-storage-blob"
   keywords:
-    - "azure"
     - "storage"
+    - "storage-blob"
+    - "azure"
     - "azure-storage-blob"
   guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/
   categories:
     - "cloud"
   status: "preview"
-  config: "quarkus.azure.storage.blob"
-
+  config: 
+    - "quarkus.azure.storage.blob."

--- a/extensions/azure-storage-blob/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-storage-blob/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,6 @@
 ---
 name: "Quarkus Support Azure Storage Blob"
+description: "Quarkus Support for Azure Storage Blob"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   short-name: "azure-storage-blob"

--- a/internal/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/internal/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -17,7 +17,7 @@
 
 ---
 name: "Quarkus Support Azure Core"
-description: "Quarkus Support Azure Core"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   unlisted: true
   keywords:

--- a/internal/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/internal/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -17,6 +17,7 @@
 
 ---
 name: "Quarkus Support Azure Core"
+description: "Quarkus Support Azure Core"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   unlisted: true

--- a/internal/http-client-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/internal/http-client-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -17,7 +17,7 @@
 
 ---
 name: "Quarkus Support Azure Core HTTP Client Vert.x"
-description: "Quarkus Support Azure Core HTTP Client Vert.x"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   unlisted: true
   keywords:

--- a/internal/http-client-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/internal/http-client-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -17,6 +17,7 @@
 
 ---
 name: "Quarkus Support Azure Core HTTP Client Vert.x"
+description: "Quarkus Support Azure Core HTTP Client Vert.x"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   unlisted: true

--- a/internal/jackson-dataformat-xml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/internal/jackson-dataformat-xml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -17,6 +17,7 @@
 
 ---
 name: "Quarkus Support Azure Jackson Dataformat XML"
+description: "Native support for Jackson Dataformat XML"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   unlisted: true

--- a/internal/jackson-dataformat-xml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/internal/jackson-dataformat-xml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -17,7 +17,7 @@
 
 ---
 name: "Quarkus Support Azure Jackson Dataformat XML"
-description: "Native support for Jackson Dataformat XML"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   unlisted: true
   keywords:


### PR DESCRIPTION
After upgrading to quarkus 3.0, some errors are observed when running dev mode for `integration-tests/azure-app-configuration` and `integration-tests/azure-storage-blob`.

<details>
  <summary>Error details:</summary>
  
  ```
  2023-06-09 16:29:04,545 ERROR [io.qua.dev.dep.DevUIProcessor] (build-8) Failed to process extension descriptor file:///mnt/c/Users/jiangma/Workspace/repos/quarkus-azure-services/internal/jackson-dataformat-xml/runtime/target/classes/META-INF/quarkus-extension.yaml: java.lang.RuntimeException: Failed to locate 'artifact' or 'group-id' and 'artifact-id' among metadata keys [name, description, metadata]
          at io.quarkus.devui.deployment.DevUIProcessor.getExtensionNamespace(DevUIProcessor.java:709)
          at io.quarkus.devui.deployment.DevUIProcessor.lambda$getAllExtensions$1(DevUIProcessor.java:425)
          at io.quarkus.runtime.util.ClassPathUtils.lambda$consumeAsPath$0(ClassPathUtils.java:121)
          at io.quarkus.runtime.util.ClassPathUtils.processAsPath(ClassPathUtils.java:161)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPath(ClassPathUtils.java:120)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:104)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:85)
          at io.quarkus.devui.deployment.DevUIProcessor.getAllExtensions(DevUIProcessor.java:409)
          at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
          at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
          at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
          at java.base/java.lang.reflect.Method.invoke(Method.java:566)
          at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
          at io.quarkus.builder.BuildContext.run(BuildContext.java:282)
          at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
          at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
          at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
          at java.base/java.lang.Thread.run(Thread.java:829)
          at org.jboss.threads.JBossThread.run(JBossThread.java:501)
  
  2023-06-09 16:29:04,654 ERROR [io.qua.dev.dep.DevUIProcessor] (build-8) Failed to process extension descriptor file:///mnt/c/Users/jiangma/Workspace/repos/quarkus-azure-services/internal/core/runtime/target/classes/META-INF/quarkus-extension.yaml: java.lang.RuntimeException: Failed to locate 'artifact' or 'group-id' and 'artifact-id' among metadata keys [name, description, metadata]
          at io.quarkus.devui.deployment.DevUIProcessor.getExtensionNamespace(DevUIProcessor.java:709)
          at io.quarkus.devui.deployment.DevUIProcessor.lambda$getAllExtensions$1(DevUIProcessor.java:425)
          at io.quarkus.runtime.util.ClassPathUtils.lambda$consumeAsPath$0(ClassPathUtils.java:121)
          at io.quarkus.runtime.util.ClassPathUtils.processAsPath(ClassPathUtils.java:161)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPath(ClassPathUtils.java:120)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:104)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:85)
          at io.quarkus.devui.deployment.DevUIProcessor.getAllExtensions(DevUIProcessor.java:409)
          at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
          at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
          at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
          at java.base/java.lang.reflect.Method.invoke(Method.java:566)
          at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
          at io.quarkus.builder.BuildContext.run(BuildContext.java:282)
          at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
          at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
          at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
          at java.base/java.lang.Thread.run(Thread.java:829)
          at org.jboss.threads.JBossThread.run(JBossThread.java:501)
  
  2023-06-09 16:29:04,677 ERROR [io.qua.dev.dep.DevUIProcessor] (build-8) Failed to process extension descriptor file:///mnt/c/Users/jiangma/Workspace/repos/quarkus-azure-services/internal/http-client-vertx/runtime/target/classes/META-INF/quarkus-extension.yaml: java.lang.RuntimeException: Failed to locate 'artifact' or 'group-id' and 'artifact-id' among metadata keys [name, description, metadata]
          at io.quarkus.devui.deployment.DevUIProcessor.getExtensionNamespace(DevUIProcessor.java:709)
          at io.quarkus.devui.deployment.DevUIProcessor.lambda$getAllExtensions$1(DevUIProcessor.java:425)
          at io.quarkus.runtime.util.ClassPathUtils.lambda$consumeAsPath$0(ClassPathUtils.java:121)
          at io.quarkus.runtime.util.ClassPathUtils.processAsPath(ClassPathUtils.java:161)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPath(ClassPathUtils.java:120)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:104)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:85)
          at io.quarkus.devui.deployment.DevUIProcessor.getAllExtensions(DevUIProcessor.java:409)
          at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
          at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
          at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
          at java.base/java.lang.reflect.Method.invoke(Method.java:566)
          at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
          at io.quarkus.builder.BuildContext.run(BuildContext.java:282)
          at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
          at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
          at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
          at java.base/java.lang.Thread.run(Thread.java:829)
          at org.jboss.threads.JBossThread.run(JBossThread.java:501)
  
  2023-06-09 16:29:04,704 ERROR [io.qua.dev.dep.DevUIProcessor] (build-8) Failed to process extension descriptor file:///mnt/c/Users/jiangma/Workspace/repos/quarkus-azure-services/extensions/azure-storage-blob/runtime/target/classes/META-INF/quarkus-extension.yaml: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.util.List (java.lang.String and java.util.List are in module java.base of loader 'bootstrap')
          at io.quarkus.devui.deployment.DevUIProcessor.lambda$getAllExtensions$1(DevUIProcessor.java:448)
          at io.quarkus.runtime.util.ClassPathUtils.lambda$consumeAsPath$0(ClassPathUtils.java:121)
          at io.quarkus.runtime.util.ClassPathUtils.processAsPath(ClassPathUtils.java:161)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPath(ClassPathUtils.java:120)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:104)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:85)
          at io.quarkus.devui.deployment.DevUIProcessor.getAllExtensions(DevUIProcessor.java:409)
          at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
          at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
          at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
          at java.base/java.lang.reflect.Method.invoke(Method.java:566)
          at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
          at io.quarkus.builder.BuildContext.run(BuildContext.java:282)
          at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
          at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
          at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
          at java.base/java.lang.Thread.run(Thread.java:829)
          at org.jboss.threads.JBossThread.run(JBossThread.java:501)

  2023-06-12 14:54:33,156 ERROR [io.qua.dev.dep.DevUIProcessor] (build-28) Failed to process extension descriptor file:///mnt/c/Users/jiangma/Workspace/repos/quarkus-azure-services/extensions/azure-app-configuration/runtime/target/classes/META-INF/quarkus-extension.yaml: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.util.List (java.lang.String and java.util.List are in module java.base of loader 'bootstrap')
          at io.quarkus.devui.deployment.DevUIProcessor.lambda$getAllExtensions$1(DevUIProcessor.java:438)
          at io.quarkus.runtime.util.ClassPathUtils.lambda$consumeAsPath$0(ClassPathUtils.java:121)
          at io.quarkus.runtime.util.ClassPathUtils.processAsPath(ClassPathUtils.java:161)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPath(ClassPathUtils.java:120)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:104)
          at io.quarkus.runtime.util.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:85)
          at io.quarkus.devui.deployment.DevUIProcessor.getAllExtensions(DevUIProcessor.java:399)
          at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
          at java.base/java.lang.reflect.Method.invoke(Method.java:578)
          at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
          at io.quarkus.builder.BuildContext.run(BuildContext.java:282)
          at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
          at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
          at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
          at java.base/java.lang.Thread.run(Thread.java:1589)
          at org.jboss.threads.JBossThread.run(JBossThread.java:501)
  ```
</details>

The PR is to resolve these errors by fixing malformed metadata in extensions, see references:
* [QUARKUS EXTENSION METADATA](https://quarkus.io/guides/extension-metadata)
* https://github.com/quarkusio/quarkus/issues/32414

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>