### PR TITLE
Fix all asciidoc warnings

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-azure-app-configuration.adoc
+++ b/docs/modules/ROOT/pages/quarkus-azure-app-configuration.adoc
@@ -1,5 +1,7 @@
 = Quarkus Azure App Configuration Extension
 
+include::./includes/attributes.adoc[]
+
 https://azure.microsoft.com/products/app-configuration[Azure App Configuration] is a fast, scalable parameter storage for app configuration.
 This extension allows to inject a `io.smallrye.config.SmallRyeConfig` object inside your Quarkus application so you can access the app configuration stored in Azure.
 

--- a/docs/modules/ROOT/pages/quarkus-azure-storage-blob.adoc
+++ b/docs/modules/ROOT/pages/quarkus-azure-storage-blob.adoc
@@ -1,5 +1,7 @@
 = Quarkus Azure Blob Storage Extension
 
+include::./includes/attributes.adoc[]
+
 https://azure.microsoft.com/products/storage/blobs[Azure Blob Storage] is a massively scalable and secure object storage for cloud-native workloads, archives, data lakes, high-performance computing, and machine learning.
 This extension allows you to store and retrieve blobs from Azure Blob Storage by injecting a `com.azure.storage.blob.BlobServiceClient` object inside your Quarkus application.
 


### PR DESCRIPTION
Asciidoc interprets strings like ${project-version} as attributes and then issues a WARN during the build that it will skip reference to a missing attribute. This PR removes [subs attribute](https://docs.asciidoctor.org/asciidoc/latest/subs/apply-subs-to-blocks/#the-subs-attribute) from code blocks so that Asciidoctor won't perform substitutions inside them.

Proof of all warnings gone:
<img width="954" alt="image" src="https://github.com/quarkiverse/quarkus-azure-services/assets/11942401/d9395bf1-8d2c-4c13-a51c-f20727bbe897">

Proof of warnings before this PR:
<img width="1042" alt="image" src="https://github.com/quarkiverse/quarkus-azure-services/assets/11942401/ed59f5df-30de-4218-8abe-f8ab50470650">
