### PR TITLE
Revert PR 121

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -2,27 +2,27 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>io.quarkiverse.azureservices</groupId>
         <artifactId>quarkus-azure-services-parent</artifactId>
         <version>999-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    
+
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-bom</artifactId>
     <name>Quarkus Azure Services :: BOM</name>
     <version>999-SNAPSHOT</version>
     <packaging>pom</packaging>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        
+
         <azure-sdk-bom.version>1.2.13</azure-sdk-bom.version>
     </properties>
-    
+
     <dependencyManagement>
         <dependencies>
             <!-- Azure sdk dependencies, imported as a BOM -->
@@ -33,7 +33,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>msal4j</artifactId>
@@ -51,7 +51,7 @@
                 <artifactId>woodstox-core</artifactId>
                 <version>${woodstox-core.version}</version>
             </dependency>
-            
+
             <!-- Azure Services Extensions -->
             <dependency>
                 <groupId>io.quarkiverse.azureservices</groupId>
@@ -71,6 +71,16 @@
             <dependency>
                 <groupId>io.quarkiverse.azureservices</groupId>
                 <artifactId>quarkus-azure-app-configuration-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.azureservices</groupId>
+                <artifactId>quarkus-azure-http-client-vertx</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.azureservices</groupId>
+                <artifactId>quarkus-azure-http-client-vertx-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -9,11 +9,11 @@
         <version>999-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    
+
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-docs</artifactId>
     <name>Quarkus Azure Services :: Documentation</name>
-    
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -32,7 +32,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <dependencies>
         <!-- Make sure the doc is built after the other artifacts -->
         <dependency>
@@ -59,8 +59,20 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-http-client-vertx-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
-    
+
     <build>
         <sourceDirectory>modules/ROOT/examples</sourceDirectory>
         <plugins>

--- a/extensions/azure-storage-blob/deployment/pom.xml
+++ b/extensions/azure-storage-blob/deployment/pom.xml
@@ -9,11 +9,15 @@
         <version>999-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    
+
     <artifactId>quarkus-azure-storage-blob-deployment</artifactId>
     <name>Quarkus Azure Services :: Extension :: Azure Storage Blob :: Deployment</name>
-    
+
     <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-http-client-vertx-deployment</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
@@ -24,13 +28,9 @@
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.azureservices</groupId>
-            <artifactId>quarkus-azure-core-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.azureservices</groupId>
             <artifactId>quarkus-azure-storage-blob</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
@@ -72,7 +72,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/extensions/azure-storage-blob/runtime/pom.xml
+++ b/extensions/azure-storage-blob/runtime/pom.xml
@@ -9,18 +9,18 @@
         <version>999-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    
+
     <artifactId>quarkus-azure-storage-blob</artifactId>
     <name>Quarkus Azure Services :: Extension :: Azure Storage Blob :: Runtime</name>
-    
+
     <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-http-client-vertx</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.azureservices</groupId>
-            <artifactId>quarkus-azure-core</artifactId>
         </dependency>
         <!-- See https://github.com/quarkusio/quarkus/issues/26879 -->
         <dependency>
@@ -33,12 +33,8 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-core-http-vertx</artifactId>
-        </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/internal/http-client-vertx/deployment/pom.xml
+++ b/internal/http-client-vertx/deployment/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.azureservices</groupId>
+        <artifactId>quarkus-azure-http-client-vertx-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-azure-http-client-vertx-deployment</artifactId>
+    <name>Quarkus Azure Services :: Internal :: HTTP Client Vert.x :: Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-http-client-vertx</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/internal/http-client-vertx/deployment/src/main/java/io/quarkiverse/azure/core/http/vertx/deployment/AzureCoreHttpClientVertxProcessor.java
+++ b/internal/http-client-vertx/deployment/src/main/java/io/quarkiverse/azure/core/http/vertx/deployment/AzureCoreHttpClientVertxProcessor.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.azure.core.http.vertx.deployment;
+
+import com.azure.core.http.vertx.VertxProvider;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+
+public class AzureCoreHttpClientVertxProcessor {
+
+    @BuildStep
+    void registerServiceProviders(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(VertxProvider.class.getName()));
+    }
+}

--- a/internal/http-client-vertx/pom.xml
+++ b/internal/http-client-vertx/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.azureservices</groupId>
+        <artifactId>quarkus-azure-extensions</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../extensions/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-azure-http-client-vertx-parent</artifactId>
+    <name>Quarkus Azure Services :: Internal :: HTTP Client Vert.x</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/internal/http-client-vertx/runtime/pom.xml
+++ b/internal/http-client-vertx/runtime/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.azureservices</groupId>
+        <artifactId>quarkus-azure-http-client-vertx-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-azure-http-client-vertx</artifactId>
+    <name>Quarkus Azure Services :: Internal :: HTTP Client Vert.x :: Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/internal/http-client-vertx/runtime/src/main/java/io/quarkiverse/azure/core/http/vertx/runtime/QuarkusVertxProvider.java
+++ b/internal/http-client-vertx/runtime/src/main/java/io/quarkiverse/azure/core/http/vertx/runtime/QuarkusVertxProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.azure.core.http.vertx.runtime;
+
+import java.util.Set;
+
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+
+import com.azure.core.http.vertx.VertxProvider;
+
+import io.vertx.core.Vertx;
+
+public class QuarkusVertxProvider implements VertxProvider {
+    @Override
+    public Vertx createVertx() {
+        BeanManager beanManager = CDI.current().getBeanManager();
+        Set<Bean<?>> beans = beanManager.getBeans(Vertx.class);
+        if (beans.isEmpty()) {
+            throw new IllegalStateException("Failed to discover Vert.x bean from the CDI bean manager");
+        }
+
+        if (beans.size() > 1) {
+            throw new IllegalStateException(
+                    "Expected 1 Vert.x bean in the CDI bean manager but " + beans.size() + " were found");
+        }
+
+        Bean<?> bean = beanManager.resolve(beans);
+        Object reference = beanManager.getReference(bean, Vertx.class, beanManager.createCreationalContext(bean));
+        return (Vertx) reference;
+    }
+}

--- a/internal/http-client-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/internal/http-client-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+name: "Quarkus Support Azure Core HTTP Client Vert.x"
+description: "Quarkus Support Azure Core HTTP Client Vert.x"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  unlisted: true
+  keywords:
+    - "azure"
+  guide: "https://quarkus.io/guides/deploying-to-azure-cloud"
+  categories:
+    - "cloud"

--- a/internal/http-client-vertx/runtime/src/main/resources/META-INF/services/com.azure.core.http.vertx.VertxProvider
+++ b/internal/http-client-vertx/runtime/src/main/resources/META-INF/services/com.azure.core.http.vertx.VertxProvider
@@ -1,0 +1,1 @@
+io.quarkiverse.azure.core.http.vertx.runtime.QuarkusVertxProvider

--- a/internal/pom.xml
+++ b/internal/pom.xml
@@ -8,12 +8,12 @@
         <version>999-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    
+
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-internal</artifactId>
     <name>Quarkus Azure Services :: Internal</name>
     <packaging>pom</packaging>
-    
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -32,9 +32,10 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <modules>
         <module>core</module>
         <module>jackson-dataformat-xml</module>
+        <module>http-client-vertx</module>
     </modules>
 </project>


### PR DESCRIPTION
After merging #121, I observed a warning message when running the sample app `integration-tests/azure-storage-blob` as a native exectuable:

```
You're already on a Vert.x context, are you sure you want to create a new Vertx instance?
```

After looking around, the warning message is most probably due to calling `Vertx.vertx()` in `com.azure:azure-core-http-vertx`. More details pls see https://github.com/vert-x3/vertx-web/issues/1117.

So the PR is to revert #121 to get rid of the warning message, which is verified locally.