### PR TITLE
Add readme for sample apps

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-azure-app-configuration.adoc
+++ b/docs/modules/ROOT/pages/quarkus-azure-app-configuration.adoc
@@ -123,8 +123,8 @@ public class ConfigResource {
 
 To execute this sample you can run the following cURL commands:
 
-* `curl -X POST localhost:8080/config/myKeyOne`
-* `curl -X POST localhost:8080/config/myKeyTwo`
+* `curl -X GET localhost:8080/config/myKeyOne`
+* `curl -X GET localhost:8080/config/myKeyTwo`
 
 
 == Extension Configuration Reference

--- a/extensions/azure-app-configuration/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-app-configuration/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,7 +9,7 @@ metadata:
     - "configuration"
     - "azure"
     - "azure-app-configuration"
-  guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/
+  guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/quarkus-azure-app-configuration.html
   categories:
     - "cloud"
   status: "preview"

--- a/extensions/azure-storage-blob/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-storage-blob/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,7 +9,7 @@ metadata:
     - "storage-blob"
     - "azure"
     - "azure-storage-blob"
-  guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/
+  guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/quarkus-azure-storage-blob.html
   categories:
     - "cloud"
   status: "preview"

--- a/integration-tests/azure-app-configuration/README.md
+++ b/integration-tests/azure-app-configuration/README.md
@@ -1,0 +1,133 @@
+# Azure App Configuration sample
+
+This is a sample about implementing REST endpoints using the Quarkus extension to get the configuration stored in Azure
+App Configuration.
+
+## Prerequisites
+
+To successfully run this sample, you need:
+
+* JDK 11+ installed with JAVA_HOME configured appropriately
+* Apache Maven 3.8.6+
+* Azure CLI and Azure subscription if the specific Azure services are required
+* Docker if you want to build the app as a native executable
+
+## Preparing the Azure services
+
+The Quarkus Azure app configuration extension needs to connect to a real Azure app configuration store, follow steps
+below to create one.
+
+### Logging into Azure
+
+Log into Azure and create a resource group for hosting the Azure App Configuration store to be created.
+
+```
+az login
+
+RESOURCE_GROUP_NAME=<resource-group-name>
+az group create \
+    --name ${RESOURCE_GROUP_NAME} \
+    --location eastus
+```
+
+### Creating Azure App Configuration store
+
+Run the following commands to create an Azure App Configuration store, add a few key-value pairs, and export its
+connection info as environment variables.
+
+```
+export APP_CONFIG_NAME=<unique-app-config-name>
+az appconfig create \
+    --name "${APP_CONFIG_NAME}" \
+    --resource-group "${RESOURCE_GROUP_NAME}" \
+    --location eastus
+
+az appconfig kv set \
+    --name "${APP_CONFIG_NAME}" \
+    --key my.prop \
+    --value 1234 \
+    --yes
+az appconfig kv set \
+    --name "${APP_CONFIG_NAME}" \
+    --key another.prop \
+    --value 5678 \
+    --yes
+    
+export QUARKUS_AZURE_APP_CONFIGURATION_ENDPOINT=$(az appconfig show \
+  --resource-group "${RESOURCE_GROUP_NAME}" \
+  --name "${APP_CONFIG_NAME}" \
+  --query endpoint -o tsv)
+credential=$(az appconfig credential list \
+    --name "${APP_CONFIG_NAME}" \
+    --resource-group "${RESOURCE_GROUP_NAME}" \
+    | jq 'map(select(.readOnly == true)) | .[0]')
+export QUARKUS_AZURE_APP_CONFIGURATION_ID=$(echo "${credential}" | jq -r '.id')
+export QUARKUS_AZURE_APP_CONFIGURATION_SECRET=$(echo "${credential}" | jq -r '.value')
+```
+
+The values of environment
+variable `QUARKUS_AZURE_APP_CONFIGURATION_ENDPOINT` / `QUARKUS_AZURE_APP_CONFIGURATION_ID` / `QUARKUS_AZURE_APP_CONFIGURATION_SECRET`
+will be fed into config
+properties `quarkus.azure.app.configuration.endpoint` / `quarkus.azure.app.configuration.id` / `quarkus.azure.app.configuration.secret`
+of `azure-app-configuration` extension in order to set up the connection to the Azure App Configuration store.
+
+## Running the sample
+
+You have different choices to run the sample.
+
+### Running the sample in development mode
+
+First, you can launch the sample in `dev` mode.
+
+```
+mvn -Djvm.args="-Dvertx.disableDnsResolver=true" quarkus:dev
+```
+
+### Running the sample in JVM mode
+
+You can also run the sample in JVM mode.
+
+```
+# Build the package.
+mvn package
+
+# Run the generated jar file.
+java -Dvertx.disableDnsResolver=true -jar ./target/quarkus-app/quarkus-run.jar
+```
+
+### Running the sample as a native executable
+
+You can even run the sample as a native executable. Make sure you have installed Docker.
+
+```
+# Build the native executable using the Docker.
+mvn package -Dnative -Dquarkus.native.container-build
+
+# Run the native executable.
+version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+./target/quarkus-azure-integration-test-app-configuration-${version}-runner
+```
+
+## Testing the sample
+
+Open a new terminal and run the following commands to test the sample:
+
+```
+# Get the value of property "my.prop" stored in the Azure app configuration. You should see "1234" in the response.
+curl http://localhost:8080/config/my.prop -X GET
+
+# Get the value of property "another.prop" stored in the Azure app configuration. You should see "5678" in the response.
+curl http://localhost:8080/config/another.prop -X GET
+```
+
+Press `Ctrl + C` to stop the sample once you complete the try and test.
+
+## Cleaning up Azure resources
+
+Run the following command to clean up the Azure resources if you created before:
+
+```
+az group delete \
+    --name ${RESOURCE_GROUP_NAME} \
+    --yes --no-wait
+```

--- a/integration-tests/azure-storage-blob/README.md
+++ b/integration-tests/azure-storage-blob/README.md
@@ -1,0 +1,131 @@
+# Azure Blob Storage sample
+
+This is a sample about implementing REST endpoints using the Quarkus Azure storage blob extension to upload and download
+files to/from Azure Blob Storage.
+
+## Prerequisites
+
+To successfully run this sample, you need:
+
+* JDK 11+ installed with JAVA_HOME configured appropriately
+* Apache Maven 3.8.6+
+* Azure CLI and Azure subscription if the specific Azure services are required
+* Docker if you want to build the app as a native executable
+
+## Preparing the Azure services
+
+The Quarkus Azure storage blob extension supports **Dev Services**, it allows to run the sample without the real Azure
+storage blob created and configured in the `dev` or `test` modes, you can go
+to [Running the sample in development mode](#running-the-sample-in-development-mode) and have a try. However, if you
+want to run the sample in JVM mode or as a native executable, you need to prepare the Azure storage blob first.
+
+### Logging into Azure
+
+Log into Azure and create a resource group for hosting the Azure storage blob to be created.
+
+```
+az login
+
+RESOURCE_GROUP_NAME=<resource-group-name>
+az group create \
+    --name ${RESOURCE_GROUP_NAME} \
+    --location eastus
+```
+
+### Creating Azure Storage Account
+
+Run the following commands to create an Azure Storage Account and export its connection string as an environment
+variable.
+
+```
+STORAGE_ACCOUNT_NAME=<unique-storage-account-name>
+az storage account create \
+    --name ${STORAGE_ACCOUNT_NAME} \
+    --resource-group ${RESOURCE_GROUP_NAME} \
+    --location eastus \
+    --sku Standard_LRS \
+    --kind StorageV2
+
+export QUARKUS_AZURE_STORAGE_BLOB_CONNECTION_STRING=$(az storage account show-connection-string \
+    --resource-group ${RESOURCE_GROUP_NAME} \
+    --name ${STORAGE_ACCOUNT_NAME} \
+    --query connectionString -o tsv)
+echo "The value of 'quarkus.azure.storage.blob.connection-string' is: ${QUARKUS_AZURE_STORAGE_BLOB_CONNECTION_STRING}"
+```
+
+The value of environment variable `QUARKUS_AZURE_STORAGE_BLOB_CONNECTION_STRING` will be fed into config
+property `quarkus.azure.storage.blob.connection-string` of `azure-storage-blob` extension in order to set up the
+connection to the Azure Storage Account.
+
+You can also manually copy the output of the variable `quarkus.azure.storage.blob.connection-string` and then
+update [application.properties](src/main/resources/application.properties) by uncommenting the
+same property and setting copied value.
+
+## Running the sample
+
+You have different choices to run the sample.
+
+### Running the sample in development mode
+
+First, you can launch the sample in `dev` mode.
+
+```
+mvn quarkus:dev
+```
+
+### Running the sample in JVM mode
+
+You can also run the sample in JVM mode. Make sure you have
+followed [Preparing the Azure services](#preparing-the-azure-services) to create the required Azure services.
+
+```
+# Build the package.
+mvn package
+
+# Run the generated jar file.
+java -jar ./target/quarkus-app/quarkus-run.jar
+```
+
+### Running the sample as a native executable
+
+You can even run the sample as a native executable. Make sure you have installed Docker and
+followed [Preparing the Azure services](#preparing-the-azure-services) to create the required Azure services.
+
+```
+# Build the native executable using the Docker.
+mvn package -Dnative -Dquarkus.native.container-build
+
+# Run the native executable.
+version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+./target/quarkus-azure-integration-test-storage-blob-${version}-runner
+```
+
+## Testing the sample
+
+Open a new terminal and run the following commands to test the sample:
+
+```
+# Upload a blob with "Hello Quarkus Azure Storage Blob!" to Azure Blob Storage.
+curl http://localhost:8080/quarkus-azure-storage-blob/testcontainer/testblob -X POST -d 'Hello Quarkus Azure Storage Blob!' -H "Content-Type: text/plain"
+
+# Download the blob from Azure Blob Storage. You should see "Hello Quarkus Azure Storage Blob!" in the response.
+curl http://localhost:8080/quarkus-azure-storage-blob/testcontainer/testblob -X GET
+
+# Delete the blob from Azure Blob Storage.
+curl http://localhost:8080/quarkus-azure-storage-blob/testcontainer/testblob -X DELETE
+
+# Download the blob from Azure Blob Storage again. You should see "404 Not Found" in the response.
+curl http://localhost:8080/quarkus-azure-storage-blob/testcontainer/testblob -X GET -I
+```
+
+Press `Ctrl + C` to stop the sample once you complete the try and test.
+
+## Cleaning up Azure resources
+
+Run the following command to clean up the Azure resources if you created before:
+
+```
+az group delete \
+    --name ${RESOURCE_GROUP_NAME} \
+    --yes --no-wait
+```


### PR DESCRIPTION
The major change of the PR is to add readme for two sample apps `integration-tests/azure-app-configuration` and `integration-tests/azure-storage-blob`, which supports running the app in:
* `dev` mode
* JVM mode
* Native executable

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>