### PR TITLE
Update readme and exclude module `integration-tests` from release

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Example applications can be found inside the [integration-tests](integration-tes
 
 - [Azure App Configuration sample](integration-tests/azure-app-configuration): REST endpoint using the Quarkus extension
   to get the configuration stored in Azure App Configuration.
-- [Azure Blob Storage samples](integration-tests/azure-storage-blob): REST endpoint using the Quarkus extension to
+- [Azure Blob Storage sample](integration-tests/azure-storage-blob): REST endpoint using the Quarkus extension to
   upload and download files to/from Azure Blob Storage.
 
 ## Release

--- a/README.md
+++ b/README.md
@@ -1,23 +1,33 @@
 # Quarkiverse - Quarkus Azure Services
+
+[![Build](https://github.com/quarkiverse/quarkus-azure-services/workflows/Build/badge.svg?branch=main)](https://github.com/quarkiverse/quarkus-azure-services/actions?query=workflow%3ABuild)
+[![License](https://img.shields.io/github/license/quarkiverse/quarkus-azure-services.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![Central](https://img.shields.io/maven-central/v/io.quarkiverse.azureservices/quarkus-azure-services-parent?color=green)](https://central.sonatype.com/artifact/io.quarkiverse.azureservices/quarkus-azure-services-parent)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-This repository hosts Quarkus extensions for different Azure Services. You can check the [documentation of these services](https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/index.html).
+This repository hosts Quarkus extensions for different Azure Services. You can check
+the [documentation of these services](https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/index.html).
 
 ## Azure Services
 
 The following extensions allows you to interact with some of the Azure Services:
 
-- [Quarkus Azure App Configuration Extension](https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/quarkus-azure-app-configuration.html): [Azure App Configuration](https://azure.microsoft.com/products/app-configuration) is a fast, scalable parameter storage for app configuration.
-- [Quarkus Azure Blob Storage Extension](https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/quarkus-azure-storage-blob.html): [Azure Blob Storage](https://azure.microsoft.com/products/storage/blobs/) is a massively scalable and secure object storage for cloud-native workloads, archives, data lakes, high-performance computing, and machine learning.
+- [Quarkus Azure App Configuration Extension](https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/quarkus-azure-app-configuration.html): [Azure App Configuration](https://azure.microsoft.com/products/app-configuration)
+  is a fast, scalable parameter storage for app configuration.
+- [Quarkus Azure Blob Storage Extension](https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/quarkus-azure-storage-blob.html): [Azure Blob Storage](https://azure.microsoft.com/products/storage/blobs/)
+  is a massively scalable and secure object storage for cloud-native workloads, archives, data lakes, high-performance
+  computing, and machine learning.
 
 ## Example applications
 
 Example applications can be found inside the [integration-tests](integration-tests) folder:
 
-- [Azure App Configuration sample](integration-tests/azure-app-configuration): REST endpoint using the Quarkus extension to get the configuration stored in Azure App Configuration.
-- [Azure Blob Storage samples](integration-tests/azure-storage-blob): REST endpoint using the Quarkus extension to upload and download files to/from Azure Blob Storage.
+- [Azure App Configuration sample](integration-tests/azure-app-configuration): REST endpoint using the Quarkus extension
+  to get the configuration stored in Azure App Configuration.
+- [Azure Blob Storage samples](integration-tests/azure-storage-blob): REST endpoint using the Quarkus extension to
+  upload and download files to/from Azure Blob Storage.
 
 ## Contributing
 
@@ -55,4 +65,5 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification.
+Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Example applications can be found inside the [integration-tests](integration-tes
 - [Azure Blob Storage samples](integration-tests/azure-storage-blob): REST endpoint using the Quarkus extension to
   upload and download files to/from Azure Blob Storage.
 
+## Release
+
+Follow [this wiki](https://github.com/quarkiverse/quarkiverse/wiki/Release) to release a new version of the extensions.
+You can reference the following PRs as examples:
+
+* Release a new version: https://github.com/quarkiverse/quarkus-azure-services/pull/133
+* Register new extensions in catalog: https://github.com/quarkusio/quarkus-extension-catalog/pull/64.
+  See [Publish your extension in registry.quarkus.io](https://quarkus.io/guides/writing-extensions#publish-your-extension-in-registry-quarkus-io)
+  for more information.
+
 ## Contributing
 
 Contributions are always welcome, but better create an issue to discuss them prior to any contributions.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Example applications can be found inside the [integration-tests](integration-tes
 - [Azure Blob Storage sample](integration-tests/azure-storage-blob): REST endpoint using the Quarkus extension to
   upload and download files to/from Azure Blob Storage.
 
-## Release
+## How to release a new version
 
 Follow [this wiki](https://github.com/quarkiverse/quarkiverse/wiki/Release) to release a new version of the extensions.
 You can reference the following PRs as examples:

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -2,6 +2,23 @@
 
 This is the integration test for testing all Quarkus Azure services extensions from REST endpoints.
 
+## Installing dependencies locally in development iteration
+
+The version of Quarkus Azure services extensions in development iteration is `999-SNAPSHOT`, which is not available
+from Maven Central, you need to install them locally before running the test.
+
+```
+# Switch to the root directory of Quarkus Azure services extensions.
+# For example, if you are in the directory of quarkus-azure-services/integration-tests
+cd ..
+
+# Install all Quarkus Azure services extensions locally.
+mvn clean install -DskipTests
+
+# Switch back to the directory of integration-tests
+cd integration-tests
+```
+
 ## Running the test with Dev services
 
 Some Quarkus Azure services extensions support Dev Services, it allows to test easily.

--- a/integration-tests/azure-app-configuration/README.md
+++ b/integration-tests/azure-app-configuration/README.md
@@ -12,6 +12,44 @@ To successfully run this sample, you need:
 * Azure CLI and Azure subscription if the specific Azure services are required
 * Docker if you want to build the app as a native executable
 
+You also need to make sure the right version of dependencies are installed.
+
+### Use development iteration version
+
+By default, the sample depends on the development iteration version, which is `999-SNAPSHOT`. To install the development
+iteration version, you need to build it locally.
+
+```
+# Switch to the root directory of Quarkus Azure services extensions.
+# For example, if you are in the directory of quarkus-azure-services/integration-tests/azure-app-configuration
+cd ../..
+
+# Install all Quarkus Azure services extensions locally.
+mvn clean install -DskipTests
+
+# Switch back to the directory of integration-tests/azure-app-configuration
+cd integration-tests/azure-app-configuration
+```
+
+### Use release version
+
+If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
+
+First, you need to find out the latest release version of the Quarkus Azure services extensions
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.0.0`.
+
+Then, update the version of dependencies in the `pom.xml` file, for example:
+
+```xml
+
+<parent>
+    <groupId>io.quarkiverse.azureservices</groupId>
+    <artifactId>quarkus-azure-integration-test</artifactId>
+    <version>1.0.0</version>
+    <!--        <relativePath>../pom.xml</relativePath>-->
+</parent>
+```
+
 ## Preparing the Azure services
 
 The Quarkus Azure app configuration extension needs to connect to a real Azure app configuration store, follow steps

--- a/integration-tests/azure-app-configuration/README.md
+++ b/integration-tests/azure-app-configuration/README.md
@@ -44,9 +44,9 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
-    <artifactId>quarkus-azure-integration-test</artifactId>
+    <artifactId>quarkus-azure-services-parent</artifactId>
     <version>1.0.0</version>
-    <!--        <relativePath>../pom.xml</relativePath>-->
+    <relativePath></relativePath>
 </parent>
 ```
 

--- a/integration-tests/azure-app-configuration/pom.xml
+++ b/integration-tests/azure-app-configuration/pom.xml
@@ -3,13 +3,32 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.azureservices</groupId>
-        <artifactId>quarkus-azure-integration-test</artifactId>
+        <artifactId>quarkus-azure-services-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>quarkus-azure-integration-test-app-configuration</artifactId>
     <name>Quarkus Azure Services :: Integration Test :: Azure App Configuration</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.azureservices</groupId>
+                <artifactId>quarkus-azure-services-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/integration-tests/azure-storage-blob/README.md
+++ b/integration-tests/azure-storage-blob/README.md
@@ -44,9 +44,9 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
-    <artifactId>quarkus-azure-integration-test</artifactId>
+    <artifactId>quarkus-azure-services-parent</artifactId>
     <version>1.0.0</version>
-    <!--        <relativePath>../pom.xml</relativePath>-->
+    <relativePath></relativePath>
 </parent>
 ```
 

--- a/integration-tests/azure-storage-blob/README.md
+++ b/integration-tests/azure-storage-blob/README.md
@@ -12,6 +12,44 @@ To successfully run this sample, you need:
 * Azure CLI and Azure subscription if the specific Azure services are required
 * Docker if you want to build the app as a native executable
 
+You also need to make sure the right version of dependencies are installed.
+
+### Use development iteration version
+
+By default, the sample depends on the development iteration version, which is `999-SNAPSHOT`. To install the development
+iteration version, you need to build it locally.
+
+```
+# Switch to the root directory of Quarkus Azure services extensions.
+# For example, if you are in the directory of quarkus-azure-services/integration-tests/azure-storage-blob
+cd ../..
+
+# Install all Quarkus Azure services extensions locally.
+mvn clean install -DskipTests
+
+# Switch back to the directory of integration-tests/azure-storage-blob
+cd integration-tests/azure-storage-blob
+```
+
+### Use release version
+
+If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
+
+First, you need to find out the latest release version of the Quarkus Azure services extensions
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.0.0`.
+
+Then, update the version of dependencies in the `pom.xml` file, for example:
+
+```xml
+
+<parent>
+    <groupId>io.quarkiverse.azureservices</groupId>
+    <artifactId>quarkus-azure-integration-test</artifactId>
+    <version>1.0.0</version>
+    <!--        <relativePath>../pom.xml</relativePath>-->
+</parent>
+```
+
 ## Preparing the Azure services
 
 The Quarkus Azure storage blob extension supports **Dev Services**, it allows to run the sample without the real Azure

--- a/integration-tests/azure-storage-blob/pom.xml
+++ b/integration-tests/azure-storage-blob/pom.xml
@@ -3,13 +3,32 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.azureservices</groupId>
-        <artifactId>quarkus-azure-integration-test</artifactId>
+        <artifactId>quarkus-azure-services-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>quarkus-azure-integration-test-storage-blob</artifactId>
     <name>Quarkus Azure Services :: Integration Test :: Azure Storage Blob</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.azureservices</groupId>
+                <artifactId>quarkus-azure-services-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -20,19 +39,6 @@
             <groupId>io.quarkiverse.azureservices</groupId>
             <artifactId>quarkus-azure-storage-blob</artifactId>
         </dependency>
-        <!-- See https://github.com/quarkusio/quarkus/issues/26879
-        <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-aot-graalvm-support</artifactId>
-            <version>1.0.0-beta.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-aot-graalvm-support-netty</artifactId>
-            <version>1.0.0-beta.3</version>
-        </dependency>
-        -->
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -13,25 +13,6 @@
     <name>Quarkus Azure Services :: Integration Test</name>
     <packaging>pom</packaging>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkiverse.azureservices</groupId>
-                <artifactId>quarkus-azure-services-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <modules>
         <module>azure-app-configuration</module>
         <module>azure-storage-blob</module>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
     <module>bom</module>
     <module>docs</module>
     <module>extensions</module>
-    <module>integration-tests</module>
     <module>internal</module>
   </modules>
   <build>
@@ -60,4 +59,18 @@
       </plugins>
     </pluginManagement>
   </build>
+  <profiles>
+    <profile>
+      <id>it</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <modules>
+        <module>integration-tests</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
The PR is to enhance readme by:
* add release process
* add more badges
* add instructions on deps installation for integ-tests
* add instructions on deps installation for sample apps

It also includes a commit to exclude module `integration-tests` from release, see [this](https://github.com/quarkiverse/quarkiverse/wiki/Release#release-fails-while-deploying-the-integration-tests) for more information.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>