### PR TITLE
Adjust doc title

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: quarkus-azure-services
-title: Azure Services Extensions
+title: Azure Services
 version: dev
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: quarkus-azure-services
-title: Quarkus Azure Services Extensions
+title: Azure Services Extensions
 version: dev
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
This will remove the  `Quarkus ` prefix in the documentation title