### PR TITLE
Use `graal-sdk` instead of `svm`

### DIFF
--- a/internal/core/runtime/pom.xml
+++ b/internal/core/runtime/pom.xml
@@ -69,8 +69,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Caused by https://github.com/quarkusio/quarkus/pull/34145