### PR TITLE
Refactor deps mgt

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -3,10 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.quarkiverse.azureservices</groupId>
-        <artifactId>quarkus-azure-services-parent</artifactId>
-        <version>999-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <groupId>io.quarkiverse</groupId>
+        <artifactId>quarkiverse-parent</artifactId>
+        <version>15</version>
     </parent>
 
     <groupId>io.quarkiverse.azureservices</groupId>
@@ -16,10 +15,12 @@
     <packaging>pom</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
         <azure-sdk-bom.version>1.2.14</azure-sdk-bom.version>
+        <azure.core.http.client.vertx.version>1.0.0-beta.9</azure.core.http.client.vertx.version>
+        <!-- @sync com.azure:azure-identity:${azure-identity.version} dep:com.microsoft.azure:msal4j -->
+        <msal4j.version>1.13.9</msal4j.version>
+        <!-- needed for dependency convergence until Azure SDK is upgraded  -->
+        <woodstox-core.version>6.5.1</woodstox-core.version>
     </properties>
 
     <dependencyManagement>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -12,25 +12,6 @@
     <artifactId>quarkus-azure-services-docs</artifactId>
     <name>Quarkus Azure Services :: Documentation</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkiverse.azureservices</groupId>
-                <artifactId>quarkus-azure-services-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Make sure the doc is built after the other artifacts -->
         <dependency>

--- a/extensions/azure-app-configuration/runtime/pom.xml
+++ b/extensions/azure-app-configuration/runtime/pom.xml
@@ -75,6 +75,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/extensions/azure-storage-blob/deployment/pom.xml
+++ b/extensions/azure-storage-blob/deployment/pom.xml
@@ -74,6 +74,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/extensions/azure-storage-blob/runtime/pom.xml
+++ b/extensions/azure-storage-blob/runtime/pom.xml
@@ -52,6 +52,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -13,25 +13,6 @@
     <name>Quarkus Azure Services :: Extension</name>
     <packaging>pom</packaging>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkiverse.azureservices</groupId>
-                <artifactId>quarkus-azure-services-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <modules>
         <module>azure-app-configuration</module>
         <module>azure-storage-blob</module>

--- a/integration-tests/azure-app-configuration/pom.xml
+++ b/integration-tests/azure-app-configuration/pom.xml
@@ -11,25 +11,6 @@
     <artifactId>quarkus-azure-integration-test-app-configuration</artifactId>
     <name>Quarkus Azure Services :: Integration Test :: Azure App Configuration</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkiverse.azureservices</groupId>
-                <artifactId>quarkus-azure-services-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/azure-storage-blob/pom.xml
+++ b/integration-tests/azure-storage-blob/pom.xml
@@ -11,25 +11,6 @@
     <artifactId>quarkus-azure-integration-test-storage-blob</artifactId>
     <name>Quarkus Azure Services :: Integration Test :: Azure Storage Blob</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkiverse.azureservices</groupId>
-                <artifactId>quarkus-azure-services-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/internal/jackson-dataformat-xml/deployment/pom.xml
+++ b/internal/jackson-dataformat-xml/deployment/pom.xml
@@ -29,6 +29,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/internal/jackson-dataformat-xml/runtime/pom.xml
+++ b/internal/jackson-dataformat-xml/runtime/pom.xml
@@ -39,6 +39,7 @@
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/internal/pom.xml
+++ b/internal/pom.xml
@@ -13,25 +13,6 @@
     <name>Quarkus Azure Services :: Internal</name>
     <packaging>pom</packaging>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkiverse.azureservices</groupId>
-                <artifactId>quarkus-azure-services-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <modules>
         <module>core</module>
         <module>jackson-dataformat-xml</module>

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,6 @@
   <version>999-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-    <azure.core.http.client.vertx.version>1.0.0-beta.9</azure.core.http.client.vertx.version>
-    <msal4j.version>1.13.9</msal4j.version> <!-- @sync com.azure:azure-identity:${azure-identity.version} dep:com.microsoft.azure:msal4j -->
-    <woodstox-core.version>6.5.1</woodstox-core.version> <!-- needed for dependency convergence until Azure SDK is upgraded  -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>11</maven.compiler.source>
@@ -34,6 +31,24 @@
     <module>extensions</module>
     <module>internal</module>
   </modules>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${quarkus.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.azureservices</groupId>
+        <artifactId>quarkus-azure-services-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <build>
     <pluginManagement>
       <plugins>
@@ -42,7 +57,7 @@
           <artifactId>maven-enforcer-plugin</artifactId>
           <configuration>
             <rules>
-              <dependencyConvergence />
+              <dependencyConvergence/>
             </rules>
           </configuration>
         </plugin>


### PR DESCRIPTION
The PR is to refactor the dependencies management including:
* moving duplicated `dependencyManagement` section to single source `pom.xml` in root folder.
* moving some `properties` from `pom.xml` to `bom/pom.xml` where they're actually used.
* adding missed groupId for some `maven-compiler-plugin`.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>