### PR TITLE
Set applicationId in ClientOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This repository hosts Quarkus extensions for different Azure Services. You can check
-the [documentation of these services](https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/index.html).
+the [documentation of these services](https://docs.quarkiverse.io/quarkus-azure-services/dev/index.html).
 
 ## Azure Services
 
 The following extensions allows you to interact with some of the Azure Services:
 
-- [Quarkus Azure App Configuration Extension](https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/quarkus-azure-app-configuration.html): [Azure App Configuration](https://azure.microsoft.com/products/app-configuration)
+- [Quarkus Azure App Configuration Extension](https://docs.quarkiverse.io/quarkus-azure-services/dev/quarkus-azure-app-configuration.html): [Azure App Configuration](https://azure.microsoft.com/products/app-configuration)
   is a fast, scalable parameter storage for app configuration.
-- [Quarkus Azure Blob Storage Extension](https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/quarkus-azure-storage-blob.html): [Azure Blob Storage](https://azure.microsoft.com/products/storage/blobs/)
+- [Quarkus Azure Blob Storage Extension](https://docs.quarkiverse.io/quarkus-azure-services/dev/quarkus-azure-storage-blob.html): [Azure Blob Storage](https://azure.microsoft.com/products/storage/blobs/)
   is a massively scalable and secure object storage for cloud-native workloads, archives, data lakes, high-performance
   computing, and machine learning.
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -60,6 +60,13 @@
                 <version>${woodstox-core.version}</version>
             </dependency>
             
+            <!-- Utilities for Azure Services Extensions -->
+            <dependency>
+                <groupId>io.quarkiverse.azureservices</groupId>
+                <artifactId>quarkus-azure-core-util</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            
             <!-- Azure Services Extensions -->
             <dependency>
                 <groupId>io.quarkiverse.azureservices</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,19 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
+    
     <parent>
         <groupId>io.quarkiverse</groupId>
         <artifactId>quarkiverse-parent</artifactId>
         <version>15</version>
     </parent>
-
+    
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-bom</artifactId>
     <name>Quarkus Azure Services :: BOM</name>
     <version>999-SNAPSHOT</version>
     <packaging>pom</packaging>
-
+    
+    <scm>
+        <connection>scm:git:git@github.com:quarkiverse/quarkus-azure-services.git</connection>
+        <developerConnection>scm:git:git@github.com:quarkiverse/quarkus-azure-services.git</developerConnection>
+        <url>https://github.com/quarkiverse/quarkus-azure-services</url>
+        <tag>HEAD</tag>
+    </scm>
+    
     <properties>
         <azure-sdk-bom.version>1.2.14</azure-sdk-bom.version>
         <azure.core.http.client.vertx.version>1.0.0-beta.9</azure.core.http.client.vertx.version>
@@ -22,7 +30,7 @@
         <!-- needed for dependency convergence until Azure SDK is upgraded  -->
         <woodstox-core.version>6.5.1</woodstox-core.version>
     </properties>
-
+    
     <dependencyManagement>
         <dependencies>
             <!-- Azure sdk dependencies, imported as a BOM -->
@@ -33,7 +41,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
+            
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>msal4j</artifactId>
@@ -51,7 +59,7 @@
                 <artifactId>woodstox-core</artifactId>
                 <version>${woodstox-core.version}</version>
             </dependency>
-
+            
             <!-- Azure Services Extensions -->
             <dependency>
                 <groupId>io.quarkiverse.azureservices</groupId>

--- a/extensions/azure-app-configuration/runtime/pom.xml
+++ b/extensions/azure-app-configuration/runtime/pom.xml
@@ -17,7 +17,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.azureservices</groupId>
@@ -52,6 +53,10 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core-http-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-core-util</artifactId>
         </dependency>
     </dependencies>
     

--- a/extensions/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
+++ b/extensions/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
@@ -17,14 +17,13 @@ import com.azure.data.appconfiguration.ConfigurationClientBuilder;
 import com.azure.data.appconfiguration.models.ConfigurationSetting;
 import com.azure.data.appconfiguration.models.SettingSelector;
 
+import io.quarkiverse.azure.core.util.AzureQuarkusIdentifier;
 import io.smallrye.config.ConfigSourceContext;
 import io.smallrye.config.ConfigSourceFactory.ConfigurableConfigSourceFactory;
 import io.vertx.core.Vertx;
 
 public class AzureAppConfigurationConfigSourceFactory
         implements ConfigurableConfigSourceFactory<AzureAppConfigurationConfig> {
-
-    private static final String AZURE_QUARKUS_APP_CONFIGURATION = "az-qk-app-config";
 
     @Override
     public Iterable<ConfigSource> getConfigSources(
@@ -41,7 +40,7 @@ public class AzureAppConfigurationConfigSourceFactory
         VertxAsyncHttpClientBuilder httpClientBuilder = new VertxAsyncHttpClientBuilder().vertx(vertx);
 
         ConfigurationClientBuilder clientBuilder = new ConfigurationClientBuilder()
-                .clientOptions(new ClientOptions().setApplicationId(AZURE_QUARKUS_APP_CONFIGURATION))
+                .clientOptions(new ClientOptions().setApplicationId(AzureQuarkusIdentifier.AZURE_QUARKUS_APP_CONFIGURATION))
                 .httpClient(httpClientBuilder.build())
                 .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.NONE))
                 .connectionString(config.connectionString());

--- a/extensions/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
+++ b/extensions/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
@@ -1,27 +1,28 @@
 package io.quarkiverse.azure.app.configuration;
 
+import com.azure.core.http.policy.HttpLogDetailLevel;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.http.vertx.VertxAsyncHttpClientBuilder;
+import com.azure.core.util.ClientOptions;
+import com.azure.data.appconfiguration.ConfigurationClient;
+import com.azure.data.appconfiguration.ConfigurationClientBuilder;
+import com.azure.data.appconfiguration.models.ConfigurationSetting;
+import com.azure.data.appconfiguration.models.SettingSelector;
+import io.smallrye.config.ConfigSourceContext;
+import io.smallrye.config.ConfigSourceFactory.ConfigurableConfigSourceFactory;
+import io.vertx.core.Vertx;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import org.eclipse.microprofile.config.spi.ConfigSource;
-
-import com.azure.core.http.policy.HttpLogDetailLevel;
-import com.azure.core.http.policy.HttpLogOptions;
-import com.azure.core.http.rest.PagedIterable;
-import com.azure.core.http.vertx.VertxAsyncHttpClientBuilder;
-import com.azure.data.appconfiguration.ConfigurationClient;
-import com.azure.data.appconfiguration.ConfigurationClientBuilder;
-import com.azure.data.appconfiguration.models.ConfigurationSetting;
-import com.azure.data.appconfiguration.models.SettingSelector;
-
-import io.smallrye.config.ConfigSourceContext;
-import io.smallrye.config.ConfigSourceFactory.ConfigurableConfigSourceFactory;
-import io.vertx.core.Vertx;
-
 public class AzureAppConfigurationConfigSourceFactory
         implements ConfigurableConfigSourceFactory<AzureAppConfigurationConfig> {
+
+    private static final String AZURE_QUARKUS_APP_CONFIGURATION = "az-qk-app-config";
 
     @Override
     public Iterable<ConfigSource> getConfigSources(
@@ -38,6 +39,7 @@ public class AzureAppConfigurationConfigSourceFactory
         VertxAsyncHttpClientBuilder httpClientBuilder = new VertxAsyncHttpClientBuilder().vertx(vertx);
 
         ConfigurationClientBuilder clientBuilder = new ConfigurationClientBuilder()
+                .clientOptions(new ClientOptions().setApplicationId(AZURE_QUARKUS_APP_CONFIGURATION))
                 .httpClient(httpClientBuilder.build())
                 .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.NONE))
                 .connectionString(config.connectionString());

--- a/extensions/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
+++ b/extensions/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
@@ -7,8 +7,6 @@ import java.util.function.Consumer;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
-import com.azure.core.http.policy.HttpLogDetailLevel;
-import com.azure.core.http.policy.HttpLogOptions;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.vertx.VertxAsyncHttpClientBuilder;
 import com.azure.core.util.ClientOptions;
@@ -42,7 +40,6 @@ public class AzureAppConfigurationConfigSourceFactory
         ConfigurationClientBuilder clientBuilder = new ConfigurationClientBuilder()
                 .clientOptions(new ClientOptions().setApplicationId(AzureQuarkusIdentifier.AZURE_QUARKUS_APP_CONFIGURATION))
                 .httpClient(httpClientBuilder.build())
-                .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.NONE))
                 .connectionString(config.connectionString());
 
         ConfigurationClient client = clientBuilder.buildClient();

--- a/extensions/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
+++ b/extensions/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
@@ -1,5 +1,12 @@
 package io.quarkiverse.azure.app.configuration;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
 import com.azure.core.http.policy.HttpLogDetailLevel;
 import com.azure.core.http.policy.HttpLogOptions;
 import com.azure.core.http.rest.PagedIterable;
@@ -9,15 +16,10 @@ import com.azure.data.appconfiguration.ConfigurationClient;
 import com.azure.data.appconfiguration.ConfigurationClientBuilder;
 import com.azure.data.appconfiguration.models.ConfigurationSetting;
 import com.azure.data.appconfiguration.models.SettingSelector;
+
 import io.smallrye.config.ConfigSourceContext;
 import io.smallrye.config.ConfigSourceFactory.ConfigurableConfigSourceFactory;
 import io.vertx.core.Vertx;
-import org.eclipse.microprofile.config.spi.ConfigSource;
-
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.function.Consumer;
 
 public class AzureAppConfigurationConfigSourceFactory
         implements ConfigurableConfigSourceFactory<AzureAppConfigurationConfig> {

--- a/extensions/azure-app-configuration/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-app-configuration/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,9 +10,9 @@ metadata:
     - "configuration"
     - "azure"
     - "azure-app-configuration"
-  guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/quarkus-azure-app-configuration.html
+  guide: https://docs.quarkiverse.io/quarkus-azure-services/dev/quarkus-azure-app-configuration.html
   categories:
     - "cloud"
   status: "preview"
-  config: 
+  config:
     - "quarkus.azure.app.configuration."

--- a/extensions/azure-storage-blob/runtime/pom.xml
+++ b/extensions/azure-storage-blob/runtime/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.azureservices</groupId>
@@ -7,10 +8,10 @@
         <version>999-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-
+    
     <artifactId>quarkus-azure-storage-blob</artifactId>
     <name>Quarkus Azure Services :: Extension :: Azure Storage Blob :: Runtime</name>
-
+    
     <dependencies>
         <dependency>
             <groupId>io.quarkiverse.azureservices</groupId>
@@ -31,8 +32,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-core-util</artifactId>
+        </dependency>
     </dependencies>
-
+    
     <build>
         <plugins>
             <plugin>

--- a/extensions/azure-storage-blob/runtime/src/main/java/io/quarkiverse/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
+++ b/extensions/azure-storage-blob/runtime/src/main/java/io/quarkiverse/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
@@ -1,18 +1,23 @@
 package io.quarkiverse.azure.storage.blob.runtime;
 
+import com.azure.core.util.ClientOptions;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
-import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.BlobServiceClientBuilder;
-
 public class StorageBlobServiceClientProducer {
+
+    private static final String AZURE_QUARKUS_STORAGE_BLOB = "az-qk-storage-blob";
 
     @Inject
     StorageBlobConfig storageBlobConfiguration;
 
     @Produces
     public BlobServiceClient blobServiceClient() {
-        return new BlobServiceClientBuilder().connectionString(storageBlobConfiguration.connectionString).buildClient();
+        return new BlobServiceClientBuilder()
+                .clientOptions(new ClientOptions().setApplicationId(AZURE_QUARKUS_STORAGE_BLOB))
+                .connectionString(storageBlobConfiguration.connectionString)
+                .buildClient();
     }
 }

--- a/extensions/azure-storage-blob/runtime/src/main/java/io/quarkiverse/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
+++ b/extensions/azure-storage-blob/runtime/src/main/java/io/quarkiverse/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
@@ -1,10 +1,11 @@
 package io.quarkiverse.azure.storage.blob.runtime;
 
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
 import com.azure.core.util.ClientOptions;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
-import jakarta.enterprise.inject.Produces;
-import jakarta.inject.Inject;
 
 public class StorageBlobServiceClientProducer {
 

--- a/extensions/azure-storage-blob/runtime/src/main/java/io/quarkiverse/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
+++ b/extensions/azure-storage-blob/runtime/src/main/java/io/quarkiverse/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
@@ -7,9 +7,9 @@ import com.azure.core.util.ClientOptions;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 
-public class StorageBlobServiceClientProducer {
+import io.quarkiverse.azure.core.util.AzureQuarkusIdentifier;
 
-    private static final String AZURE_QUARKUS_STORAGE_BLOB = "az-qk-storage-blob";
+public class StorageBlobServiceClientProducer {
 
     @Inject
     StorageBlobConfig storageBlobConfiguration;
@@ -17,7 +17,7 @@ public class StorageBlobServiceClientProducer {
     @Produces
     public BlobServiceClient blobServiceClient() {
         return new BlobServiceClientBuilder()
-                .clientOptions(new ClientOptions().setApplicationId(AZURE_QUARKUS_STORAGE_BLOB))
+                .clientOptions(new ClientOptions().setApplicationId(AzureQuarkusIdentifier.AZURE_QUARKUS_STORAGE_BLOB))
                 .connectionString(storageBlobConfiguration.connectionString)
                 .buildClient();
     }

--- a/extensions/azure-storage-blob/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-storage-blob/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,9 +10,9 @@ metadata:
     - "storage-blob"
     - "azure"
     - "azure-storage-blob"
-  guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/quarkus-azure-storage-blob.html
+  guide: https://docs.quarkiverse.io/quarkus-azure-services/dev/quarkus-azure-storage-blob.html
   categories:
     - "cloud"
   status: "preview"
-  config: 
+  config:
     - "quarkus.azure.storage.blob."

--- a/internal/core/pom.xml
+++ b/internal/core/pom.xml
@@ -17,7 +17,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.azureservices</groupId>
@@ -25,13 +26,14 @@
         <version>999-SNAPSHOT</version>
         <relativePath>../../extensions/pom.xml</relativePath>
     </parent>
-
+    
     <artifactId>quarkus-azure-core-parent</artifactId>
     <name>Quarkus Azure Services :: Internal :: Core</name>
     <packaging>pom</packaging>
-
+    
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>util</module>
     </modules>
 </project>

--- a/internal/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/internal/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -23,7 +23,6 @@ metadata:
   icon-url: "https://learn.microsoft.com/en-us/media/logos/logo_azure.svg"
   unlisted: true
   keywords:
-  - "azure"
-  guide: "https://quarkus.io/guides/deploying-to-azure-cloud"
+    - "azure"
   categories:
-  - "cloud"
+    - "cloud"

--- a/internal/core/util/pom.xml
+++ b/internal/core/util/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.azureservices</groupId>
+        <artifactId>quarkus-azure-core-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    
+    <artifactId>quarkus-azure-core-util</artifactId>
+    <name>Quarkus Azure Services :: Internal :: Core :: Util</name>
+
+</project>

--- a/internal/core/util/src/main/java/io/quarkiverse/azure/core/util/AzureQuarkusIdentifier.java
+++ b/internal/core/util/src/main/java/io/quarkiverse/azure/core/util/AzureQuarkusIdentifier.java
@@ -6,7 +6,12 @@ package io.quarkiverse.azure.core.util;
  * @implNote The identifier is used to identify the Azure Quarkus Extension, and its max length is limited to 24 characters.
  * @since 1.0.1
  */
-public class AzureQuarkusIdentifier {
+public final class AzureQuarkusIdentifier {
+
     public static final String AZURE_QUARKUS_APP_CONFIGURATION = "az-qk-app-config";
     public static final String AZURE_QUARKUS_STORAGE_BLOB = "az-qk-storage-blob";
+
+    private AzureQuarkusIdentifier() {
+
+    }
 }

--- a/internal/core/util/src/main/java/io/quarkiverse/azure/core/util/AzureQuarkusIdentifier.java
+++ b/internal/core/util/src/main/java/io/quarkiverse/azure/core/util/AzureQuarkusIdentifier.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.azure.core.util;
+
+/**
+ * Util class for Azure Quarkus Identifier.
+ *
+ * @implNote The identifier is used to identify the Azure Quarkus Extension, and its max length is limited to 24 characters.
+ * @since 1.0.1
+ */
+public class AzureQuarkusIdentifier {
+    public static final String AZURE_QUARKUS_APP_CONFIGURATION = "az-qk-app-config";
+    public static final String AZURE_QUARKUS_STORAGE_BLOB = "az-qk-storage-blob";
+}

--- a/internal/http-client-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/internal/http-client-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -24,6 +24,5 @@ metadata:
   unlisted: true
   keywords:
     - "azure"
-  guide: "https://quarkus.io/guides/deploying-to-azure-cloud"
   categories:
     - "cloud"

--- a/internal/jackson-dataformat-xml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/internal/jackson-dataformat-xml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -23,10 +23,9 @@ metadata:
   icon-url: "https://learn.microsoft.com/en-us/media/logos/logo_azure.svg"
   unlisted: true
   keywords:
-  - "azure"
-  - "jackson"
-  - "dataformat"
-  - "xml"
-  guide: "https://quarkiverse.github.io/quarkiverse-docs/quarkus-azure-services/dev/"
+    - "azure"
+    - "jackson"
+    - "dataformat"
+    - "xml"
   categories:
-  - "cloud"
+    - "cloud"


### PR DESCRIPTION
The major change of the PR is to set `applicationId` in `ClientOptions` in order to identify the client of relative Azure services is created from Quarkus extension. The PR also updates Quarkiverse documentation site with the new lived `docs.quarkiverse.io`.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>