### PR TITLE
added small section about using azure blob store in reactive code

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-azure-storage-blob.adoc
+++ b/docs/modules/ROOT/pages/quarkus-azure-storage-blob.adoc
@@ -154,6 +154,13 @@ You can go back to the http://portal.azure.com/[Azure portal] and see the contai
 
 image::quarkus-azure-storage-blob-azure-portal2.png[alt=Azure Portal showing the containt of the file]
 
+=== Reactive code pitfall
+
+In case you plan to use `BlobServiceClient` (that provides all other clients for interacting with Azure BlobStore), note that it cannot be used within the reactive code as it blocks the event loop due to the fact that `BlobServiceClient` is a wrapper around the `BlobServiceAsyncClient` and it uses blocking calls such as `blockingGet`.
+
+Using it in reactive code such as RestEasy Reactive or Reactive Messaging will cause indefinite hang of the application that prevents it from further functioning or shutdown.
+
+
 == Extension Configuration Reference
 
 include::includes/quarkus-azure-storage-blob.adoc[leveloffset=+1, opts=optional]


### PR DESCRIPTION
Small addition to the documentation about using azure blob store in reactive code, which essentially does not work and cause a fatal hang of the application.

Quarkus issue reported https://github.com/quarkusio/quarkus/issues/37299 which led to this small though useful (in my opinion) documentation update.

I believe a real solution to it would be to allow this extension to produce async client as well, which should play much better with reactive code in quarkus.