### PR TITLE
Add AzureAppConfigurationWithLabelsIT

### DIFF
--- a/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationWithLabelsIT.java
+++ b/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationWithLabelsIT.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.azure.app.configuration.it;
+
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusIntegrationTest
+@TestProfile(LabelsConfigurationProfile.class)
+@DisabledIfSystemProperty(named = "azure.test", matches = "true")
+public class AzureAppConfigurationWithLabelsIT extends AzureAppConfigurationWithLabelsTest {
+
+}


### PR DESCRIPTION
This PR is a follow-up for #158 to add an integration test running without Azure service for app config with labels.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>