### PR TITLE
Fix build error

### DIFF
--- a/.github/build-with-maven-native.sh
+++ b/.github/build-with-maven-native.sh
@@ -38,8 +38,11 @@ APP_CONFIG_CONNECTION_STRING=$(az appconfig credential list \
     | jq -r 'map(select(.readOnly == false)) | .[0].connectionString')
 while [ -z ${APP_CONFIG_CONNECTION_STRING} ]
 do
-    echo "Failed to retrieve connection string of app config {APP_CONFIG_NAME}, retry it in 5 seconds..."
+    echo "Failed to retrieve connection string of app config ${APP_CONFIG_NAME}, retry it in 5 seconds..."
     sleep 5
+    az appconfig show \
+        --resource-group "${RESOURCE_GROUP_NAME}" \
+        --name "${APP_CONFIG_NAME}"
     APP_CONFIG_CONNECTION_STRING=$(az appconfig credential list \
         --name "${APP_CONFIG_NAME}" \
         --resource-group "${RESOURCE_GROUP_NAME}" \

--- a/.github/build-with-maven-native.sh
+++ b/.github/build-with-maven-native.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
+set -Euo pipefail
 
 # The following environment variables need to be configured before running the script
 # - RESOURCE_GROUP_NAME
@@ -73,8 +73,3 @@ export QUARKUS_AZURE_APP_CONFIGURATION_SECRET=$(echo "${credential}" | jq -r '.v
 
 # Build native executable and run the integration tests against the Azure services
 mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip -Dazure.test=true
-
-# Delete the resource group
-az group delete \
-    --name "${RESOURCE_GROUP_NAME}" \
-    --yes --no-wait

--- a/.github/delete-azure-resources.sh
+++ b/.github/delete-azure-resources.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# The following environment variables need to be configured before running the script
+# - RESOURCE_GROUP_NAME
+# - STORAGE_ACCOUNT_NAME
+# - APP_CONFIG_NAME
+
+az appconfig delete --name ${APP_CONFIG_NAME} --resource-group ${RESOURCE_GROUP_NAME} --yes
+az appconfig purge --name ${APP_CONFIG_NAME} --yes
+az storage account delete --name ${STORAGE_ACCOUNT_NAME} --resource-group ${RESOURCE_GROUP_NAME} --yes
+az group delete --name ${RESOURCE_GROUP_NAME} --yes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,10 @@ jobs:
         run: .github/build-with-maven-native.sh
         if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' }}
 
+      - name: Delete Azure resources
+        run: .github/delete-azure-resources.sh
+        if: ${{ always() && env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' }}
+
       - name: Fail if there are uncommitted changes
         run: |
           [[ -z $(git status --porcelain) ]] || { echo 'There are uncommitted changes'; git status; exit 1; }

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -86,3 +86,9 @@ jobs:
           cd ${GITHUB_WORKSPACE}/current-repo/integration-tests
           ../.github/build-with-maven-native.sh
         if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' }}
+
+      - name: Delete Azure resources
+        run: |
+          cd ${GITHUB_WORKSPACE}/current-repo/integration-tests
+          ../.github/delete-azure-resources.sh
+        if: ${{ always() && env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' }}


### PR DESCRIPTION
Sometimes app config store is not available when trying to add kv pairs. The PR is to fix the issue by retrieving the connection string with retry-logic. It also makes sure the Azure resources are deleted no matter the job failed or not.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>