### PR TITLE
Rollback to 1.0.2 and skip tests depending on azure services in release process

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "1.0.3"
+  current-version: "1.0.2"
   next-version: "999-SNAPSHOT"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,11 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
+        # Skip any tests depending on real Azure serivces, e.g., azure-keyvault
         run: mvn -B clean install -Dno-format -Dskip.azure.tests=true
 
       - name: Build with Maven (Native)
+        # Skip any tests depending on real Azure serivces, e.g., azure-keyvault
         run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip -Dskip.azure.tests=true
         if: ${{ env.AZURE_CLIENT_ID == '' || env.AZURE_TENANT_ID == '' || env.AZURE_SUBSCRIPTION_ID == '' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,10 @@ jobs:
           fi
 
       - name: Maven release ${{steps.metadata.outputs.current-version}}
+        # Skip any tests depending on real Azure serivces, e.g., azure-keyvault
         run: |
-          mvn -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}
-          mvn -B release:perform -Darguments=-DperformRelease -DperformRelease -Prelease
+          mvn -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}} -Dskip.azure.tests=true
+          mvn -B release:perform -Darguments=-DperformRelease -DperformRelease -Prelease -Dskip.azure.tests=true
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:project-version: 1.0.3
+:project-version: 1.0.2
 
 :examples-dir: ./../examples/


### PR DESCRIPTION
Fix the release pipeline failure [Release 1.0.3](https://github.com/quarkiverse/quarkus-azure-services/actions/runs/8891160899).
FYI @galiacheng @edburns 