### PR TITLE
Fix build failure

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "1.0.3"
+  current-version: "1.0.2"
   next-version: "999-SNAPSHOT"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,12 +68,10 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        # Skip any tests depending on real Azure serivces, e.g., azure-keyvault
-        run: mvn -B clean install -Dno-format -Dskip.azure.tests=true
+        run: mvn -B clean install -Dno-format
 
       - name: Build with Maven (Native)
-        # Skip any tests depending on real Azure serivces, e.g., azure-keyvault
-        run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip -Dskip.azure.tests=true
+        run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip
         if: ${{ env.AZURE_CLIENT_ID == '' || env.AZURE_TENANT_ID == '' || env.AZURE_SUBSCRIPTION_ID == '' }}
 
       - name: Az CLI login

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,9 @@ jobs:
           fi
 
       - name: Maven release ${{steps.metadata.outputs.current-version}}
-        # Skip any tests depending on real Azure serivces, e.g., azure-keyvault
         run: |
-          mvn -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}} -Dskip.azure.tests=true
-          mvn -B release:perform -Darguments=-DperformRelease -DperformRelease -Prelease -Dskip.azure.tests=true
+          mvn -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}
+          mvn -B release:perform -Darguments=-DperformRelease -DperformRelease -Prelease
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:project-version: 1.0.3
+:project-version: 1.0.2
 
 :examples-dir: ./../examples/

--- a/integration-tests/azure-keyvault/README.md
+++ b/integration-tests/azure-keyvault/README.md
@@ -136,7 +136,7 @@ version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 ./target/quarkus-azure-integration-test-keyvault-secret-${version}-runner
 ```
 
-## ## Testing the sample
+## Testing the sample
 
 Open a new terminal and run the following commands to test the sample:
 

--- a/integration-tests/azure-keyvault/pom.xml
+++ b/integration-tests/azure-keyvault/pom.xml
@@ -11,12 +11,6 @@
     <artifactId>quarkus-azure-integration-test-keyvault-secret</artifactId>
     <name>Quarkus Azure Services :: Integration Test :: Azure Key Vault Secret</name>
 
-    <properties>
-        <!-- All the test requires real azure key vault service, skip the tests if setting -Dskip.azure.tests=true. -->
-        <!-- Used in build pipeline. -->
-        <maven.test.skip>${skip.azure.tests}</maven.test.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/azure-keyvault/src/test/java/io/quarkiverse/azure/keyvault/secret/it/KeyVaultSecretResourceIT.java
+++ b/integration-tests/azure-keyvault/src/test/java/io/quarkiverse/azure/keyvault/secret/it/KeyVaultSecretResourceIT.java
@@ -1,8 +1,11 @@
 package io.quarkiverse.azure.keyvault.secret.it;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
+@EnabledIfSystemProperty(named = "azure.test", matches = "true")
 public class KeyVaultSecretResourceIT extends KeyVaultSecretResourceTest {
 
 }

--- a/integration-tests/azure-keyvault/src/test/java/io/quarkiverse/azure/keyvault/secret/it/KeyVaultSecretResourceTest.java
+++ b/integration-tests/azure-keyvault/src/test/java/io/quarkiverse/azure/keyvault/secret/it/KeyVaultSecretResourceTest.java
@@ -3,11 +3,13 @@ package io.quarkiverse.azure.keyvault.secret.it;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 @QuarkusTest
+@EnabledIfSystemProperty(named = "azure.test", matches = "true")
 public class KeyVaultSecretResourceTest {
 
     @Test


### PR DESCRIPTION
We have to disable key-vault tests by default to fix the failure of pipeline [Quarkus ecosystem CI](https://github.com/quarkiverse/quarkus-azure-services/actions/runs/8905600120) and [Quarkiverse Release](https://github.com/quarkiverse/quarkus-azure-services/actions/runs/8905652736), in which there is no real Azure services available.

For pipeline of Build, key-vault tests are enabled with `-Dazure.test=true`.

Cc @galiacheng 