### PR TITLE
Recommend to configure extensions using env variables instead of  `application.properties`

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-azure-app-configuration.adoc
+++ b/docs/modules/ROOT/pages/quarkus-azure-app-configuration.adoc
@@ -24,7 +24,7 @@ For instance, with Maven, add the following dependency to your POM file:
 
 == How to Use It
 
-Once you have added the extension to your project, follow the next steps, so you can inject  `io.smallrye.config.SmallRyeConfig` object in your application to store and read blobs.
+Once you have added the extension to your project, follow the next steps, so you can inject `io.smallrye.config.SmallRyeConfig` object in your application to store and read blobs.
 
 === Setup your Azure Environment
 
@@ -77,30 +77,21 @@ For that, execute the following Azure CLI command:
 
 [source,shell]
 ----
-az appconfig credential list --name appcs-quarkus-azure-app-configuration
+export QUARKUS_AZURE_APP_CONFIGURATION_ENDPOINT=$(az appconfig show \
+  --resource-group rg-quarkus-azure-app-configuration \
+  --name appcs-quarkus-azure-app-configuration \
+  --query endpoint -o tsv)
+credential=$(az appconfig credential list \
+    --name appcs-quarkus-azure-app-configuration \
+    --resource-group rg-quarkus-azure-app-configuration \
+    | jq 'map(select(.readOnly == true)) | .[0]')
+export QUARKUS_AZURE_APP_CONFIGURATION_ID=$(echo "${credential}" | jq -r '.id')
+export QUARKUS_AZURE_APP_CONFIGURATION_SECRET=$(echo "${credential}" | jq -r '.value')
 ----
 
-You'll get the following output:
+Notice that you get the endpoint, id and secret and set them to environment variables `QUARKUS_AZURE_APP_CONFIGURATION_ENDPOINT`, `QUARKUS_AZURE_APP_CONFIGURATION_ID` and `QUARKUS_AZURE_APP_CONFIGURATION_SECRET`, instead of setting them to properties `quarkus.azure.app.configuration.endpoint`, `quarkus.azure.app.configuration.id` and `quarkus.azure.app.configuration.secret` in the `application.properties` file.
 
-[source,json]
-----
-{
-  "connectionString": "Endpoint=https://appcs-quarkus-azure-app-configuration.azconfig.io;Id=xxxxxx;Secret=xxxxxx",
-  "id": "xxxxxx",
-  "name": "Primary",
-  "readOnly": false,
-  "value": "xxxxxx"
-}
-----
-
-Then, in the `application.properties` file, add the following property according to the output of the previous command:
-
-[source,properties]
-----
-quarkus.azure.app.configuration.endpoint=https://appcs-quarkus-azure-app-configuration.azconfig.io
-quarkus.azure.app.configuration.id=xxxxxx
-quarkus.azure.app.configuration.secret=xxxxxx
-----
+Although technically both approaches work, using environment variable is recommended and more secure as there's no risk of committing the connection credentials to source control.
 
 === Inject the SmallRyeConfig
 

--- a/docs/modules/ROOT/pages/quarkus-azure-key-vault.adoc
+++ b/docs/modules/ROOT/pages/quarkus-azure-key-vault.adoc
@@ -93,7 +93,7 @@ export QUARKUS_AZURE_KEYVAULT_SECRET_ENDPOINT=$(az keyvault show --name kvquarku
 
 Notice that you get the endpoint and set it to environment variable `QUARKUS_AZURE_KEYVAULT_SECRET_ENDPOINT`, instead of setting it to property `quarkus.azure.keyvault.secret.endpoint` in the `application.properties` file.
 
-Although technically both approaches work, using environment variable is recommended and more flexible and secure as there's no risk of committing the endpoint to source control.
+Although technically both approaches work, using environment variable is recommended, more flexible and more secure as there's no risk of committing the endpoint to source control.
 
 === Inject the Azure Key Vault Secret Client
 

--- a/docs/modules/ROOT/pages/quarkus-azure-key-vault.adoc
+++ b/docs/modules/ROOT/pages/quarkus-azure-key-vault.adoc
@@ -85,18 +85,15 @@ To get the endpoint, execute the following Azure CLI command:
 
 [source,shell]
 ----
-az keyvault show --name kvquarkusazurekv0423 \
+export QUARKUS_AZURE_KEYVAULT_SECRET_ENDPOINT=$(az keyvault show --name kvquarkusazurekv0423 \
     --resource-group rg-quarkus-azure-keyvault \
     --query properties.vaultUri \
-    --output tsv
+    --output tsv)
 ----
 
-Then, in the `application.properties` file, add the following property:
+Notice that you get the endpoint and set it to environment variable `QUARKUS_AZURE_KEYVAULT_SECRET_ENDPOINT`, instead of setting it to property `quarkus.azure.keyvault.secret.endpoint` in the `application.properties` file.
 
-[source,properties]
-----
-quarkus.azure.keyvault.secret.endpoint=https://kvquarkusazurekv0423.vault.azure.net/
-----
+Although technically both approaches work, using environment variable is recommended and more flexible and secure as there's no risk of committing the endpoint to source control.
 
 === Inject the Azure Key Vault Secret Client
 

--- a/docs/modules/ROOT/pages/quarkus-azure-storage-blob.adoc
+++ b/docs/modules/ROOT/pages/quarkus-azure-storage-blob.adoc
@@ -26,7 +26,7 @@ For instance, with Maven, add the following dependency to your POM file:
 
 == How to Use It
 
-Once you have added the extension to your project, follow the next steps, so you can inject  `com.azure.storage.blob.BlobServiceClient` or `com.azure.storage.blob.BlobServiceAsyncClient` object in your application to store and read blobs.
+Once you have added the extension to your project, follow the next steps, so you can inject `com.azure.storage.blob.BlobServiceClient` or `com.azure.storage.blob.BlobServiceAsyncClient` object in your application to store and read blobs.
 
 === Setup your Azure Environment
 


### PR DESCRIPTION
This pull request includes changes to the documentation on how to handle Azure CLI commands and how to manage Azure credentials and endpoints in the `quarkus-azure-app-configuration.adoc` and `quarkus-azure-key-vault.adoc` files. The changes suggest using environment variables instead of adding properties to the `application.properties` file, which is a more secure and recommended approach.

Changes to Azure CLI commands and credential management:

* [`docs/modules/ROOT/pages/quarkus-azure-app-configuration.adoc`](diffhunk://#diff-ad82271a2fee2250768b0ecc293f13c42e3b3ceb69ef47c78fb28d294f63ec49L80-R94): Changed the Azure CLI command and the way credentials are handled. Instead of listing the credentials and adding them as properties to the `application.properties` file, the new approach exports the endpoint, id, and secret as environment variables `QUARKUS_AZURE_APP_CONFIGURATION_ENDPOINT`, `QUARKUS_AZURE_APP_CONFIGURATION_ID`, and `QUARKUS_AZURE_APP_CONFIGURATION_SECRET`. This approach is recommended as it is more secure and avoids the risk of committing the connection credentials to source control.

* [`docs/modules/ROOT/pages/quarkus-azure-key-vault.adoc`](diffhunk://#diff-43bb46d422b98950cd556aa55cfb2a2a3d8381053f235af62300fde4e518cd46L88-R96): Modified the Azure CLI command and the way the endpoint is handled. Instead of showing the endpoint and adding it as a property to the `application.properties` file, the new approach exports the endpoint as an environment variable `QUARKUS_AZURE_KEYVAULT_SECRET_ENDPOINT`. This approach is recommended as it is more secure, more flexible, and avoids the risk of committing the endpoint to source control.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>