### PR TITLE
Add reflective class `com.microsoft.aad.msal4j.ManagedIdentityResponse`

### DIFF
--- a/common/core/deployment/src/main/java/io/quarkiverse/azure/core/deployment/AzureCoreSupportProcessor.java
+++ b/common/core/deployment/src/main/java/io/quarkiverse/azure/core/deployment/AzureCoreSupportProcessor.java
@@ -65,6 +65,7 @@ public class AzureCoreSupportProcessor {
                 com.azure.core.http.HttpHeaderName.class).build());
 
         reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
+                "com.microsoft.aad.msal4j.ManagedIdentityResponse",
                 "com.microsoft.aad.msal4j.AadInstanceDiscoveryResponse",
                 "com.microsoft.aad.msal4j.InstanceDiscoveryMetadataEntry").fields().build());
 


### PR DESCRIPTION
The PR is to resolve issue observed when deploy sample integration-tests/azure-storage-blob to aca: 
```
2025-01-20 02:59:49,676 WARN  [com.mic.aad.msa.ManagedIdentityApplication] (Thread-13) [Correlation ID: 911b4f37-8c1c-45a2-8643-5b4560b4ef64] Execution of class com.microsoft.aad.msal4j.AcquireTokenByManagedIdentitySupplier failed: [Managed Identity] Unexpected exception occurred when parsing the response, HttpStatusCode: 200, Error message: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.microsoft.aad.msal4j.ManagedIdentityResponse`: cannot deserialize from Object value (no delegate- or property-based Creator): this appears to be a native image, in which case you may need to configure reflection for the class that is to be deserialized
```

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>