### PR TITLE
Add Azure Key Vault tests and test open-telemetry extension compatibility

### DIFF
--- a/integration-tests/azure-app-configuration/README.md
+++ b/integration-tests/azure-app-configuration/README.md
@@ -191,7 +191,7 @@ Run the following command to run the tests:
 
 ```
 # Run the integration tests in native mode
-mvn test-compile failsafe:integration-test -Dnative -Dazure.test=true
+mvn test-compile failsafe:integration-test failsafe:verify -Dnative -Dazure.test=true
 
 # Run the unit tests and integration tests in JVM mode
 mvn verify -Dazure.test=true

--- a/integration-tests/azure-cosmos/README.md
+++ b/integration-tests/azure-cosmos/README.md
@@ -212,7 +212,7 @@ Run the following command to run the tests:
 
 ```
 # Run the integration tests in native mode
-mvn test-compile failsafe:integration-test -Dnative -Dazure.test=true
+mvn test-compile failsafe:integration-test failsafe:verify -Dnative -Dazure.test=true
 
 # Run the unit tests and integration tests in JVM mode
 mvn verify -Dazure.test=true

--- a/integration-tests/azure-eventhubs/README.md
+++ b/integration-tests/azure-eventhubs/README.md
@@ -166,7 +166,7 @@ Run the following command to run the tests:
 
 ```
 # Run the integration tests in native mode
-mvn test-compile failsafe:integration-test -Dnative -Dazure.test=true
+mvn test-compile failsafe:integration-test failsafe:verify -Dnative -Dazure.test=true
 
 # Run the unit tests and integration tests in JVM mode
 mvn verify -Dazure.test=true

--- a/integration-tests/azure-keyvault/README.md
+++ b/integration-tests/azure-keyvault/README.md
@@ -162,7 +162,7 @@ Run the following command to run the tests:
 
 ```
 # Run the integration tests in native mode
-mvn test-compile failsafe:integration-test -Dnative -Dazure.test=true
+mvn test-compile failsafe:integration-test failsafe:verify -Dnative -Dazure.test=true
 
 # Run the unit tests and integration tests in JVM mode
 mvn verify -Dazure.test=true

--- a/integration-tests/azure-keyvault/src/main/java/io/quarkiverse/azure/keyvault/secret/it/KeyVaultSecretResource.java
+++ b/integration-tests/azure-keyvault/src/main/java/io/quarkiverse/azure/keyvault/secret/it/KeyVaultSecretResource.java
@@ -18,7 +18,7 @@ import com.azure.security.keyvault.secrets.SecretClient;
 public class KeyVaultSecretResource {
     private static final Logger LOG = Logger.getLogger(KeyVaultSecretResource.class);
 
-    public final static String TEXT = "Quarkus Azure Key Vault Extension is awsome";
+    public final static String TEXT = "Quarkus Azure Key Vault Extension is awesome";
     private static final String SYNC_PARAM = "synkv" + System.currentTimeMillis();
     private static final String ASYNC_PARAM = "asynckv" + System.currentTimeMillis();
 

--- a/integration-tests/azure-keyvault/src/test/java/io/quarkiverse/azure/keyvault/secret/it/KeyVaultSecretResourceTest.java
+++ b/integration-tests/azure-keyvault/src/test/java/io/quarkiverse/azure/keyvault/secret/it/KeyVaultSecretResourceTest.java
@@ -14,11 +14,11 @@ public class KeyVaultSecretResourceTest {
 
     @Test
     public void testSecretClient() {
-        RestAssured.when().get("/keyvault/sync").then().body(is("Quarkus Azure Key Vault Extension is awsome"));
+        RestAssured.when().get("/keyvault/sync").then().body(is("Quarkus Azure Key Vault Extension is awesome"));
     }
 
     @Test
     public void testSecretAsyncClient() {
-        RestAssured.when().get("/keyvault/async").then().body(is("Quarkus Azure Key Vault Extension is awsome"));
+        RestAssured.when().get("/keyvault/async").then().body(is("Quarkus Azure Key Vault Extension is awesome"));
     }
 }

--- a/integration-tests/azure-services-together/README.md
+++ b/integration-tests/azure-services-together/README.md
@@ -107,6 +107,15 @@ az keyvault secret set \
     --value "$AZURE_STORAGE_BLOB_CONNECTION_STRING"
 ```
 
+Add secret `secret1` with value `mysecret`.
+
+```
+az keyvault secret set \
+    --vault-name ${KEY_VAULT_NAME} \
+    --name secret1 \
+    --value mysecret
+```
+
 ### Exporting environment variables
 
 Run the following commands to export the necessary environment variables to sucessfully run the sample.
@@ -197,6 +206,12 @@ curl http://localhost:8080/quarkus-services-azure-storage-blob-async/testcontain
 
 # Download the blob from Azure Blob Storage again using the async API. You should see "404 Not Found" in the response.
 curl http://localhost:8080/quarkus-services-azure-storage-blob-async/testcontainer-async/testblob-async -X HEAD -I
+
+# Get the secret "secret1" from Azure Key Vault using the secret client. You should see "mysecret" in the response.
+curl http://localhost:8080/quarkus-services-azure-key-vault/getSecretBySecretClient -X GET
+
+# Get the secret "secret1" from Azure Key Vault using the configuration property. You should see "mysecret" in the response.
+curl http://localhost:8080/quarkus-services-azure-key-vault/getSecretByConfigProperty -X GET
 ```
 
 Press `Ctrl + C` to stop the sample once you complete the try and test.

--- a/integration-tests/azure-services-together/README.md
+++ b/integration-tests/azure-services-together/README.md
@@ -226,7 +226,7 @@ Run the following command to run the tests:
 
 ```
 # Run the integration tests in native mode
-mvn test-compile failsafe:integration-test -Dnative -Dazure.test=true
+mvn test-compile failsafe:integration-test failsafe:verify -Dnative -Dazure.test=true
 
 # Run the unit tests and integration tests in JVM mode
 mvn verify -Dazure.test=true

--- a/integration-tests/azure-services-together/pom.xml
+++ b/integration-tests/azure-services-together/pom.xml
@@ -24,6 +24,16 @@
             <groupId>io.quarkiverse.azureservices</groupId>
             <artifactId>quarkus-azure-storage-blob</artifactId>
         </dependency>
+        <!-- Test compatibility with opentelemetry extension using logging exporter -->
+        <!-- Inspired by issue https://github.com/quarkiverse/quarkus-azure-services/issues/335 -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>

--- a/integration-tests/azure-services-together/src/main/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResource.java
+++ b/integration-tests/azure-services-together/src/main/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResource.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.azure.services.together.it;
+
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import com.azure.security.keyvault.secrets.SecretClient;
+
+@Path("/quarkus-services-azure-key-vault")
+@Produces(TEXT_PLAIN)
+public class KeyVaultSecretResource {
+    private static final Logger LOG = Logger.getLogger(KeyVaultSecretResource.class);
+
+    @Inject
+    SecretClient secretClient;
+
+    @GET
+    @Path("getSecretBySecretClient")
+    public String testSecretClient(String value) {
+        LOG.info("Testing SecretClient by getting value of secret secret1");
+        return secretClient.getSecret("secret1").getValue();
+    }
+
+    @ConfigProperty(name = "kv//secret1")
+    String value;
+
+    @GET
+    @Path("getSecretByConfigProperty")
+    public String getConfigProperty() {
+        LOG.info("Testing ConfigProperty by getting value of secret secret1");
+        return value;
+    }
+}

--- a/integration-tests/azure-services-together/src/main/resources/application.properties
+++ b/integration-tests/azure-services-together/src/main/resources/application.properties
@@ -1,3 +1,9 @@
 # Intentionally disable all Azure services to pass mvn build executed in the pipeline. You should enable the services when running the sample.
 quarkus.azure.keyvault.secret.enabled=false
 quarkus.azure.storage.blob.enabled=false
+
+# OpenTelemetry configuration
+quarkus.otel.logs.enabled=true
+# Use logging exporter for testing purpose only, don't use it in production
+quarkus.otel.logs.exporter=logging
+quarkus.otel.traces.exporter=logging

--- a/integration-tests/azure-services-together/src/test/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResourceIT.java
+++ b/integration-tests/azure-services-together/src/test/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResourceIT.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.azure.services.together.it;
+
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+@EnabledIfSystemProperty(named = "azure.test", matches = "true")
+public class KeyVaultSecretResourceIT extends KeyVaultSecretResourceTest {
+
+}

--- a/integration-tests/azure-services-together/src/test/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResourceTest.java
+++ b/integration-tests/azure-services-together/src/test/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResourceTest.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.azure.services.together.it;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@EnabledIfSystemProperty(named = "azure.test", matches = "true")
+public class KeyVaultSecretResourceTest {
+
+    @Test
+    public void testKeyVaultSecret() {
+        final String value = "mysecret";
+
+        // Create secret and read it back using SecretClient
+        given()
+                .when().get("/quarkus-services-azure-key-vault/getSecretBySecretClient")
+                .then()
+                .statusCode(200)
+                .body(is(value));
+
+        // Read secret value from config property
+        given()
+                .when().get("/quarkus-services-azure-key-vault/getSecretByConfigProperty")
+                .then()
+                .statusCode(200)
+                .body(is(value));
+    }
+}

--- a/integration-tests/azure-services-together/src/test/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResourceTest.java
+++ b/integration-tests/azure-services-together/src/test/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResourceTest.java
@@ -16,7 +16,7 @@ public class KeyVaultSecretResourceTest {
     public void testKeyVaultSecret() {
         final String value = "mysecret";
 
-        // Create secret and read it back using SecretClient
+        // Read secret value from secret client
         given()
                 .when().get("/quarkus-services-azure-key-vault/getSecretBySecretClient")
                 .then()

--- a/integration-tests/azure-storage-blob/README.md
+++ b/integration-tests/azure-storage-blob/README.md
@@ -209,7 +209,7 @@ Run the following command to run the tests:
 
 ```
 # Run the integration tests in native mode
-mvn test-compile failsafe:integration-test -Dnative -Dazure.test=true
+mvn test-compile failsafe:integration-test failsafe:verify -Dnative -Dazure.test=true
 
 # Run the unit tests and integration tests in JVM mode
 mvn verify -Dazure.test=true


### PR DESCRIPTION
Inspired by #335, this pull request includes multiple changes to various integration test modules and documentation, primarily focusing on adding new test cases for Azure Key Vault secrets to test compatibility with open-telemetry extension, improving test commands and fixing typos. Here are the most important changes:

### New Test Classes:
* Introduced integration test classes for Azure Key Vault secret functionality in the `azure-services-together` module (`integration-tests/azure-services-together/src/test/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResourceIT.java`, `integration-tests/azure-services-together/src/test/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResourceTest.java`). [[1]](diffhunk://#diff-551efc454abc80ed8d2577530fdd4edb32a1b1fbf59d6b682560485b05362b58R1-R11) [[2]](diffhunk://#diff-e06b2ac9491c052364f49c654d68dd90b9dfd95dfab4064f1a0d8d580adc3a80R1-R33)
* Added new commands and endpoints to test Azure Key Vault secrets using both the secret client and configuration properties in the `azure-services-together` module (`integration-tests/azure-services-together/README.md`, `integration-tests/azure-services-together/src/main/java/io/quarkiverse/azure/services/together/it/KeyVaultSecretResource.java`). [[1]](diffhunk://#diff-17cf8bf682dbcb2192299e52b574c545dabcc1e51dff268ad1fad2f4af6db6a3R110-R118) [[2]](diffhunk://#diff-17cf8bf682dbcb2192299e52b574c545dabcc1e51dff268ad1fad2f4af6db6a3R209-R214) [[3]](diffhunk://#diff-d89dc9e0ca3b969cbe8d0ccc6646485bdd8ca2dd125086718582cf407c1020f2R1-R37)

### Dependency Updates:
* Added dependencies for OpenTelemetry to test compatibility with the logging exporter in the `azure-services-together` module (`integration-tests/azure-services-together/pom.xml`).

### Documentation Updates:
* Updated the command to run integration tests in native mode to include `failsafe:verify` in multiple `README.md` files to ensure proper test execution (`integration-tests/azure-app-configuration/README.md`, `integration-tests/azure-cosmos/README.md`, `integration-tests/azure-eventhubs/README.md`, `integration-tests/azure-keyvault/README.md`, `integration-tests/azure-services-together/README.md`, `integration-tests/azure-storage-blob/README.md`). [[1]](diffhunk://#diff-e0cabaff689084ec2c6cc8b0b114c5e905b74e2825b9539493819e9778551596L194-R194) [[2]](diffhunk://#diff-7f0db9603140f883c5de68e67df9353840d861cb1b02737ad9a87964c91166faL215-R215) [[3]](diffhunk://#diff-3c96460779d46e68252dbae437e34f43a30bcee936601f2548412245d41596bdL169-R169) [[4]](diffhunk://#diff-72ce6bea53acc1282599f72ccd4785fc62cefc306f860fcd46248d995fe0e9b4L165-R165) [[5]](diffhunk://#diff-17cf8bf682dbcb2192299e52b574c545dabcc1e51dff268ad1fad2f4af6db6a3L214-R229) [[6]](diffhunk://#diff-1f65cacb57529181d1ffbba2c9967090d34496198ed837f2ed389448bedd3b2bL212-R212)

### Code Fixes:
* Corrected a typo in the `KeyVaultSecretResource` class and its corresponding test class (`integration-tests/azure-keyvault/src/main/java/io/quarkiverse/azure/keyvault/secret/it/KeyVaultSecretResource.java`, `integration-tests/azure-keyvault/src/test/java/io/quarkiverse/azure/keyvault/secret/it/KeyVaultSecretResourceTest.java`). [[1]](diffhunk://#diff-d7d27294ddb816dc118f4e4229636de2908ed6012d9425e41b3a9ebb39d51a7dL21-R21) [[2]](diffhunk://#diff-94d25caf61cece16f77c00bb49cde5a3d295501c2f014cc29383e6e585a8c10fL17-R22)

Test passed: https://github.com/majguo/quarkus-azure-services/actions/runs/12878123422

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>