### PR TITLE
Switch to @ConfigMapping for Storage Blob build time config

### DIFF
--- a/services/azure-storage-blob/deployment/pom.xml
+++ b/services/azure-storage-blob/deployment/pom.xml
@@ -91,9 +91,6 @@
                                     <version>${quarkus.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/services/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/StorageBlobBuildTimeConfig.java
+++ b/services/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/StorageBlobBuildTimeConfig.java
@@ -1,28 +1,23 @@
 package io.quarkiverse.azure.storage.blob.deployment;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
-@ConfigRoot(name = "azure.storage.blob")
-public class StorageBlobBuildTimeConfig {
+@ConfigRoot
+@ConfigMapping(prefix = "quarkus.azure.storage.blob")
+public interface StorageBlobBuildTimeConfig {
 
     /**
      * Whether a health check is published in case the smallrye-health extension is present.
      */
-    @ConfigItem(name = "health.enabled", defaultValue = "true")
-    public boolean healthEnabled;
+    @WithName("health.enabled")
+    @WithDefault("true")
+    boolean healthEnabled();
 
     /**
      * Dev Services configuration.
      */
-    @ConfigItem
-    public DevServicesConfig devservices;
-
-    @Override
-    public String toString() {
-        return "StorageBlobBuildTimeConfig{" +
-                "healthEnabled=" + healthEnabled +
-                ", devservices=" + devservices +
-                '}';
-    }
+    StorageBlobDevServicesConfig devservices();
 }

--- a/services/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/StorageBlobDevServicesConfig.java
+++ b/services/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/StorageBlobDevServicesConfig.java
@@ -1,14 +1,13 @@
 package io.quarkiverse.azure.storage.blob.deployment;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 @ConfigGroup
-public class DevServicesConfig {
+public interface StorageBlobDevServicesConfig {
 
     /**
      * If DevServices has been explicitly enabled or disabled. DevServices is generally enabled
@@ -17,22 +16,21 @@ public class DevServicesConfig {
      * When DevServices is enabled Quarkus will attempt to automatically configure and start
      * an azurite instance when running in Dev or Test mode and when Docker is running.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enabled;
+    @WithDefault("true")
+    boolean enabled();
 
     /**
      * The container image name to use, for container based DevServices providers.
      */
-    @ConfigItem(defaultValue = DevServicesStorageBlobProcessor.IMAGE)
-    public Optional<String> imageName;
+    @WithDefault(DevServicesStorageBlobProcessor.IMAGE)
+    Optional<String> imageName();
 
     /**
      * Optional fixed port the Dev services will listen to.
      * <p>
      * If not defined, the port will be chosen randomly.
      */
-    @ConfigItem
-    public OptionalInt port;
+    OptionalInt port();
 
     /**
      * Indicates if the azurite instance managed by Quarkus Dev Services is shared.
@@ -45,8 +43,8 @@ public class DevServicesConfig {
      * <p>
      * Container sharing is only used in dev mode.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean shared;
+    @WithDefault("true")
+    boolean shared();
 
     /**
      * The value of the {@code quarkus-dev-service-azure-storage-blob} label attached to the started container.
@@ -58,36 +56,6 @@ public class DevServicesConfig {
      * <p>
      * This property is used when you need multiple shared azurite instances.
      */
-    @ConfigItem(defaultValue = "default-storage-blob")
-    public String serviceName;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        DevServicesConfig that = (DevServicesConfig) o;
-        return enabled == that.enabled && Objects.equals(imageName,
-                that.imageName) && Objects.equals(port,
-                        that.port);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(enabled, imageName, port);
-    }
-
-    @Override
-    public String toString() {
-        return "DevServicesConfig{" +
-                "enabled=" + enabled +
-                ", imageName=" + imageName +
-                ", port=" + port +
-                ", shared=" + shared +
-                ", serviceName='" + serviceName + '\'' +
-                '}';
-    }
+    @WithDefault("default-storage-blob")
+    String serviceName();
 }


### PR DESCRIPTION
Also adjusted things to use the new DevServicesConfig from core.

We plan to retire the legacy config classes at some point in the future so it's better to move everything to the new @ConfigMapping infrastructure.