### PR TITLE
Add execution configuration for quarkus-extension-maven-plugin in pom.xml

### DIFF
--- a/common/azure-identity/runtime/pom.xml
+++ b/common/azure-identity/runtime/pom.xml
@@ -33,6 +33,20 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>
+                                ${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            </deployment>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/common/core/runtime/pom.xml
+++ b/common/core/runtime/pom.xml
@@ -80,6 +80,20 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>
+                                ${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            </deployment>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/common/http-client-vertx/runtime/pom.xml
+++ b/common/http-client-vertx/runtime/pom.xml
@@ -57,6 +57,20 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>
+                                ${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            </deployment>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/common/jackson-dataformat-xml/runtime/pom.xml
+++ b/common/jackson-dataformat-xml/runtime/pom.xml
@@ -37,6 +37,20 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>
+                                ${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            </deployment>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/services/azure-app-configuration/runtime/pom.xml
+++ b/services/azure-app-configuration/runtime/pom.xml
@@ -76,7 +76,8 @@
                             <goal>extension-descriptor</goal>
                         </goals>
                         <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            <deployment>
+                                ${project.groupId}:${project.artifactId}-deployment:${project.version}
                             </deployment>
                         </configuration>
                     </execution>

--- a/services/azure-storage-blob/runtime/pom.xml
+++ b/services/azure-storage-blob/runtime/pom.xml
@@ -53,7 +53,8 @@
                             <goal>extension-descriptor</goal>
                         </goals>
                         <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            <deployment>
+                                ${project.groupId}:${project.artifactId}-deployment:${project.version}
                             </deployment>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This pull request introduces updates to the Maven `pom.xml` files for multiple modules, primarily to enhance the configuration of the `quarkus-extension-maven-plugin`. The changes include adding a version property for the plugin, configuring its execution during the compile phase, and formatting improvements for deployment configuration.

### Enhancements to `quarkus-extension-maven-plugin` configuration:

* Added the `<version>` property for `quarkus-extension-maven-plugin` and configured its execution to run during the `compile` phase in the following modules:
  - `common/azure-identity/runtime/pom.xml`
  - `common/core/runtime/pom.xml`
  - `common/http-client-vertx/runtime/pom.xml`
  - `common/jackson-dataformat-xml/runtime/pom.xml`

### Formatting improvements:

* Reformatted the `<deployment>` configuration for better readability in the following modules:
  - `services/azure-app-configuration/runtime/pom.xml`
  - `services/azure-storage-blob/runtime/pom.xml`


### Test

#### Test Steps
1. Local build the extensions of this PR: https://github.com/quarkiverse/quarkus-azure-services/pull/378
2. Running the [servicebus-workload-id](https://github.com/albers/azure-quarkus-native-demo/tree/main/servicebus-workload-id) with the local build quarkus-azure-http-client-vertx-parent extension
3. Check the native build command result


#### Test result
<img width="995" alt="image" src="https://github.com/user-attachments/assets/7389bfd0-b79a-430f-b96a-6f16345b5a56" />
