### PR TITLE
Add project skeleton for the new Azure Service Bus extension

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -158,6 +158,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkiverse.azureservices</groupId>
+                <artifactId>quarkus-azure-servicebus</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.azureservices</groupId>
+                <artifactId>quarkus-azure-servicebus-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.azureservices</groupId>
                 <artifactId>quarkus-azure-storage-blob</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/services/azure-servicebus/README.md
+++ b/services/azure-servicebus/README.md
@@ -1,0 +1,3 @@
+# Quarkus Azure Service Bus Extension
+
+[Check the documentation](https://docs.quarkiverse.io/quarkus-azure-services/dev/quarkus-azure-servicebus.html).

--- a/services/azure-servicebus/deployment/pom.xml
+++ b/services/azure-servicebus/deployment/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.azureservices</groupId>
+        <artifactId>quarkus-azure-servicebus-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-azure-servicebus-deployment</artifactId>
+    <name>Quarkus Azure Services :: Service :: Azure Service Bus :: Deployment</name>
+    <description>Interacts with Azure Service Bus through the Azure SDK for Java</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-servicebus</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/services/azure-servicebus/pom.xml
+++ b/services/azure-servicebus/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.azureservices</groupId>
+        <artifactId>quarkus-azure-extensions</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-azure-servicebus-parent</artifactId>
+    <name>Quarkus Azure Services :: Service :: Azure Service Bus</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/services/azure-servicebus/runtime/pom.xml
+++ b/services/azure-servicebus/runtime/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.azureservices</groupId>
+        <artifactId>quarkus-azure-servicebus-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-azure-servicebus</artifactId>
+    <name>Quarkus Azure Services :: Service :: Azure Service Bus :: Runtime</name>
+    <description>Interacts with Azure Service Bus through the Azure SDK for Java</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>
+                                ${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            </deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/services/azure-servicebus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/services/azure-servicebus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,17 @@
+---
+name: "Quarkus Support Azure Service Bus"
+description: "Interacts with Azure Service Bus through the Azure SDK for Java"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  icon-url: "https://learn.microsoft.com/en-us/media/logos/logo_azure.svg"
+  short-name: "azure-servicebus"
+  keywords:
+    - "azure"
+    - "servicebus"
+    - "azure-servicebus"
+  guide: "https://docs.quarkiverse.io/quarkus-azure-services/dev/quarkus-azure-servicebus.html"
+  categories:
+    - "cloud"
+  status: "preview"
+  config:
+    - "quarkus.azure.servicebus."

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -18,5 +18,6 @@
         <module>azure-keyvault</module>
         <module>azure-storage-blob</module>
         <module>azure-eventhubs</module>
+        <module>azure-servicebus</module>
     </modules>
 </project>


### PR DESCRIPTION
This PR starts my work on a new Quarkus extension that eases interaction with the Azure Service Bus through the Azure SDK for Java.

The extension scope has been previously discussed with @majguo. @backwind1233 and @edburns.

The extension will be very similar to the existing Event Hubs extension with an additional dev service that manages the lifecycle of an Azure Service Bus emulator.