### PR TITLE
Support native build

### DIFF
--- a/services/azure-servicebus/deployment/pom.xml
+++ b/services/azure-servicebus/deployment/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>quarkus-azure-http-client-vertx-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-identity-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>

--- a/services/azure-servicebus/deployment/pom.xml
+++ b/services/azure-servicebus/deployment/pom.xml
@@ -14,6 +14,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-http-client-vertx-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>

--- a/services/azure-servicebus/deployment/src/main/java/ServiceBusProcessor.java
+++ b/services/azure-servicebus/deployment/src/main/java/ServiceBusProcessor.java
@@ -1,0 +1,31 @@
+import java.util.stream.Stream;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+
+public class ServiceBusProcessor {
+
+    static final String FEATURE = "azure-servicebus";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
+        return new ExtensionSslNativeSupportBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClasses) {
+        Stream.of(
+                "com.microsoft.azure.proton.transport.proxy.impl.DigestProxyChallengeProcessorImpl",
+                "com.microsoft.azure.proton.transport.ws.impl.Utils")
+                .map(RuntimeInitializedClassBuildItem::new)
+                .forEach(runtimeInitializedClasses::produce);
+    }
+}

--- a/services/azure-servicebus/runtime/pom.xml
+++ b/services/azure-servicebus/runtime/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>quarkus-azure-http-client-vertx</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-identity</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-messaging-servicebus</artifactId>
             <exclusions>

--- a/services/azure-servicebus/runtime/pom.xml
+++ b/services/azure-servicebus/runtime/pom.xml
@@ -14,6 +14,20 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-http-client-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-messaging-servicebus</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>


### PR DESCRIPTION
With this change, the extension provides its first value to users:

In order to work with the Service Bus, only these dependencies are needed in the project:

```xml
        <dependency>
            <groupId>io.quarkiverse.azureservices</groupId>
            <artifactId>quarkus-azure-servicebus</artifactId>
            <version>${quarkus-azure-services.version}</version>
        </dependency>
```

or, if MSAL is required,

```xml
        <dependency>
            <groupId>io.quarkiverse.azureservices</groupId>
            <artifactId>quarkus-azure-servicebus</artifactId>
            <version>${quarkus-azure-services.version}</version>
        </dependency>
        <dependency>
            <groupId>io.quarkiverse.azureservices</groupId>
            <artifactId>quarkus-azure-identity</artifactId>
            <version>${quarkus-azure-services.version}</version>
        </dependency>
```

For the native build, no configuration is needed. See this [branch](https://github.com/albers/azure-quarkus-native-demo/tree/servicebus-extension) for a working example.

### Request for comments:

@backwind1233 We have two design choices here:

1. Leave it as-is. If the `DefaultAzureCredentialBuilder` should be used, `quarkus-azure-identity` has to be added by the user.
2. Provide `quarkus-azure-identity` in the extension. If only connection strings are used, an unneccesary library is included. If this is a problem for the user, the library has to be excluded.

I think use of connection strings can be considered as sort of an edge case, the normal use case should be using the `DefaultAzureCredentialBuilder`.
Therefore I recommend option 2.
