### PR TITLE
Fix reporting of configuration errors

### DIFF
--- a/services/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfig.java
+++ b/services/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfig.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
@@ -38,11 +39,12 @@ public interface AzureAppConfigurationConfig {
         if (!enabled()) {
             return "";
         }
-        assert endpoint().isPresent() : "The endpoint of the app configuration must be set";
+        String endpoint = endpoint()
+                .orElseThrow(() -> new ConfigurationException("The endpoint of the app configuration must be set"));
 
         if (id().isEmpty() || secret().isEmpty()) {
             return "";
         }
-        return "Endpoint=" + endpoint().get() + ";Id=" + id().get() + ";Secret=" + secret().get();
+        return "Endpoint=" + endpoint + ";Id=" + id().get() + ";Secret=" + secret().get();
     }
 }

--- a/services/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
+++ b/services/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
@@ -17,6 +17,7 @@ import com.azure.data.appconfiguration.models.SettingSelector;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 
 import io.quarkiverse.azure.core.util.AzureQuarkusIdentifier;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.config.ConfigSourceContext;
 import io.smallrye.config.ConfigSourceFactory.ConfigurableConfigSourceFactory;
 import io.vertx.core.Vertx;
@@ -45,7 +46,8 @@ public class AzureAppConfigurationConfigSourceFactory
         if (!config.enabled()) {
             return Collections.emptyMap();
         }
-        assert config.endpoint().isPresent() : "The endpoint of the app configuration must be set";
+        String endpoint = config.endpoint()
+                .orElseThrow(() -> new ConfigurationException("The endpoint of the app configuration must be set"));
 
         // We cannot use the Quarkus Vert.x instance, because the configuration executes before starting Vert.x
         Vertx vertx = Vertx.vertx();
@@ -57,7 +59,7 @@ public class AzureAppConfigurationConfigSourceFactory
         if (!config.connectionString().isEmpty()) {
             clientBuilder.connectionString(config.connectionString());
         } else {
-            clientBuilder.endpoint(config.endpoint().get()).credential(new DefaultAzureCredentialBuilder().build());
+            clientBuilder.endpoint(endpoint).credential(new DefaultAzureCredentialBuilder().build());
         }
         ConfigurationClient client = clientBuilder.buildClient();
 

--- a/services/azure-cosmos/runtime/src/main/java/io/quarkiverse/azure/cosmos/runtime/CosmosClientProducer.java
+++ b/services/azure-cosmos/runtime/src/main/java/io/quarkiverse/azure/cosmos/runtime/CosmosClientProducer.java
@@ -8,6 +8,7 @@ import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 
 import io.quarkiverse.azure.core.util.AzureQuarkusIdentifier;
+import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class CosmosClientProducer {
 
@@ -25,10 +26,11 @@ public class CosmosClientProducer {
             return null;
         }
 
-        assert cosmosConfiguration.endpoint().isPresent() : "The endpoint of Azure Cosmos DB must be set";
+        String endpoint = cosmosConfiguration.endpoint()
+                .orElseThrow(() -> new ConfigurationException("The endpoint of Azure Cosmos DB must be set"));
         CosmosClientBuilder builder = new CosmosClientBuilder()
                 .userAgentSuffix(AzureQuarkusIdentifier.AZURE_QUARKUS_COSMOS)
-                .endpoint(cosmosConfiguration.endpoint().get());
+                .endpoint(endpoint);
         if (cosmosConfiguration.key().isPresent()) {
             builder.key(cosmosConfiguration.key().get());
         } else {

--- a/services/azure-eventhubs/runtime/src/main/java/io/quarkiverse/azure/eventhubs/runtime/EventhubsClientProducer.java
+++ b/services/azure-eventhubs/runtime/src/main/java/io/quarkiverse/azure/eventhubs/runtime/EventhubsClientProducer.java
@@ -12,6 +12,7 @@ import com.azure.messaging.eventhubs.EventHubProducerAsyncClient;
 import com.azure.messaging.eventhubs.EventHubProducerClient;
 
 import io.quarkiverse.azure.core.util.AzureQuarkusIdentifier;
+import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class EventhubsClientProducer {
 
@@ -71,15 +72,16 @@ public class EventhubsClientProducer {
             return null;
         }
 
-        assert eventhubsConfig.namespace().isPresent() : "The namespace of Azure Event Hubs must be set";
-        assert eventhubsConfig.domainName().isPresent() : "The domain name of Azure Event Hubs must be set";
-        assert eventhubsConfig.eventhubName().isPresent() : "The event hub name of Azure Event Hubs must be set";
+        String namespace = eventhubsConfig.namespace()
+                .orElseThrow(() -> new ConfigurationException("The namespace of Azure Event Hubs must be set"));
+        String domainName = eventhubsConfig.domainName()
+                .orElseThrow(() -> new ConfigurationException("The domain name of Azure Event Hubs must be set"));
+        String eventhubName = eventhubsConfig.eventhubName()
+                .orElseThrow(() -> new ConfigurationException("The event hub name of Azure Event Hubs must be set"));
         return new EventHubClientBuilder()
                 .clientOptions(new ClientOptions().setApplicationId(AzureQuarkusIdentifier.AZURE_QUARKUS_EVENTHUBS))
-                .credential(eventhubsConfig.namespace().get()
-                        + "."
-                        + eventhubsConfig.domainName().get(),
-                        eventhubsConfig.eventhubName().get(),
+                .credential(namespace + "." + domainName,
+                        eventhubName,
                         new DefaultAzureCredentialBuilder().build());
     }
 }

--- a/services/azure-keyvault/runtime/src/main/java/io/quarkiverse/azure/keyvault/secret/runtime/KeyVaultSecretClientProducer.java
+++ b/services/azure-keyvault/runtime/src/main/java/io/quarkiverse/azure/keyvault/secret/runtime/KeyVaultSecretClientProducer.java
@@ -11,6 +11,7 @@ import com.azure.security.keyvault.secrets.SecretClientBuilder;
 
 import io.quarkiverse.azure.core.util.AzureQuarkusIdentifier;
 import io.quarkiverse.azure.keyvault.secret.runtime.config.KeyVaultSecretConfig;
+import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class KeyVaultSecretClientProducer {
 
@@ -23,10 +24,11 @@ public class KeyVaultSecretClientProducer {
             return null;
         }
 
-        assert secretConfiguration.endpoint().isPresent() : "The endpoint of Azure Key Vault Secret must be set";
+        String endpoint = secretConfiguration.endpoint()
+                .orElseThrow(() -> new ConfigurationException("The endpoint of Azure Key Vault Secret must be set"));
         return new SecretClientBuilder()
                 .clientOptions(new ClientOptions().setApplicationId(AzureQuarkusIdentifier.AZURE_QUARKUS_KEY_VAULT_SYNC_CLIENT))
-                .vaultUrl(secretConfiguration.endpoint().get())
+                .vaultUrl(endpoint)
                 .credential(new DefaultAzureCredentialBuilder().build())
                 .buildClient();
     }
@@ -37,11 +39,12 @@ public class KeyVaultSecretClientProducer {
             return null;
         }
 
-        assert secretConfiguration.endpoint().isPresent() : "The endpoint of Azure Key Vault Secret must be set";
+        String endpoint = secretConfiguration.endpoint()
+                .orElseThrow(() -> new ConfigurationException("The endpoint of Azure Key Vault Secret must be set"));
         return new SecretClientBuilder()
                 .clientOptions(
                         new ClientOptions().setApplicationId(AzureQuarkusIdentifier.AZURE_QUARKUS_KEY_VAULT_ASYNC_CLIENT))
-                .vaultUrl(secretConfiguration.endpoint().get())
+                .vaultUrl(endpoint)
                 .credential(new DefaultAzureCredentialBuilder().build())
                 .buildAsyncClient();
     }

--- a/services/azure-keyvault/runtime/src/main/java/io/quarkiverse/azure/keyvault/secret/runtime/config/KeyVaultSecretConfigUtil.java
+++ b/services/azure-keyvault/runtime/src/main/java/io/quarkiverse/azure/keyvault/secret/runtime/config/KeyVaultSecretConfigUtil.java
@@ -2,6 +2,8 @@ package io.quarkiverse.azure.keyvault.secret.runtime.config;
 
 import com.azure.security.keyvault.secrets.models.KeyVaultSecretIdentifier;
 
+import io.quarkus.runtime.configuration.ConfigurationException;
+
 public class KeyVaultSecretConfigUtil {
     private static final String AZURE_KEYVAULT_PREFIX = "kv//";
     private static final String AZURE_KEYVAULT_ENDPOINT_PREFIX = "https://";
@@ -79,9 +81,12 @@ public class KeyVaultSecretConfigUtil {
     }
 
     static String getAzureKeyVaultName(String endpoint) {
-        assert !endpoint.isEmpty() : "The endpoint of Azure Key Vault should be set.";
-        assert endpoint.startsWith(AZURE_KEYVAULT_ENDPOINT_PREFIX)
-                : "The endpoint of Azure Key Vault should start with https://.";
+        if (endpoint.isEmpty()) {
+            throw new ConfigurationException("The endpoint of Azure Key Vault should be set.");
+        }
+        if (!endpoint.startsWith(AZURE_KEYVAULT_ENDPOINT_PREFIX)) {
+            throw new ConfigurationException("The endpoint of Azure Key Vault should start with https://.");
+        }
         return endpoint.substring(AZURE_KEYVAULT_ENDPOINT_PREFIX.length()).split("\\.")[0];
     }
 

--- a/services/azure-keyvault/runtime/src/test/java/io/quarkiverse/azure/keyvault/secret/runtime/config/KeyVaultSecretConfigUtilTest.java
+++ b/services/azure-keyvault/runtime/src/test/java/io/quarkiverse/azure/keyvault/secret/runtime/config/KeyVaultSecretConfigUtilTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 
 import com.azure.security.keyvault.secrets.models.KeyVaultSecretIdentifier;
 
+import io.quarkus.runtime.configuration.ConfigurationException;
+
 class KeyVaultSecretConfigUtilTest {
 
     private static final String DEFAULT_ENDPOINT = "https://contoso.vault.azure.net/";
@@ -16,13 +18,13 @@ class KeyVaultSecretConfigUtilTest {
 
     @Test
     public void testInvalidEndPoint() {
-        assertThrows(AssertionError.class, () -> KeyVaultSecretConfigUtil.getAzureKeyVaultName(INVALID_ENDPOINT),
+        assertThrows(ConfigurationException.class, () -> KeyVaultSecretConfigUtil.getAzureKeyVaultName(INVALID_ENDPOINT),
                 "The endpoint of Azure Key Vault should start with https://.");
     }
 
     @Test
     public void testEmptyEndPoint() {
-        assertThrows(AssertionError.class, () -> KeyVaultSecretConfigUtil.getAzureKeyVaultName(""),
+        assertThrows(ConfigurationException.class, () -> KeyVaultSecretConfigUtil.getAzureKeyVaultName(""),
                 "The endpoint of Azure Key Vault should be set.");
     }
 

--- a/services/azure-storage-blob/runtime/src/main/java/io/quarkiverse/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
+++ b/services/azure-storage-blob/runtime/src/main/java/io/quarkiverse/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
@@ -10,6 +10,7 @@ import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 
 import io.quarkiverse.azure.core.util.AzureQuarkusIdentifier;
+import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class StorageBlobServiceClientProducer {
 
@@ -34,7 +35,7 @@ public class StorageBlobServiceClientProducer {
         }
 
         if (storageBlobConfiguration.endpoint().isEmpty() && storageBlobConfiguration.connectionString().isEmpty()) {
-            throw new IllegalArgumentException("The endpoint or connection string of Azure Storage blob must be set");
+            throw new ConfigurationException("The endpoint or connection string of Azure Storage blob must be set");
         }
 
         BlobServiceClientBuilder builder = new BlobServiceClientBuilder()


### PR DESCRIPTION
The checks for missing configuration values ([example](https://github.com/quarkiverse/quarkus-azure-services/blob/b3cbc3fe40c5d0d3ea79bfd30edd2e9d712170af/services/azure-eventhubs/runtime/src/main/java/io/quarkiverse/azure/eventhubs/runtime/EventhubsClientProducer.java#L74-L76)) use `alert` statements. These are not executed unless the JVM is startetd with the `-ae` parameter.

Looking around in the Quarkus code base, I found that most property validations report problems as a `ConfigurationError`.
This PR changes the guards to report problems as `ConfigurationError`.

### How to reproduce

In the attached reproducer project, execute
```shell
mvn package
java -jar target/quarkus-app/quarkus-run.jar
```
The application will fail with (shortened)
```text
2025-05-23 08:29:34,367 ERROR [io.qua.run.Application] (main) Failed to start application: java.lang.RuntimeException: Failed to start quarkus
Caused by: java.lang.RuntimeException: Error injecting com.azure.messaging.eventhubs.EventHubProducerClient org.acme.ProducerCheck.client
Caused by: java.util.NoSuchElementException: No value present
        at java.base/java.util.Optional.get(Optional.java:143)
```
indicating that the guard statements were ignored and `Optional.get()` was called on an empty `Optional`.

Now run with assertions enabled:
```shell
java -ea -jar target/quarkus-app/quarkus-run.jar
```
Your will now get the desired error message (shortened):
```text
2025-05-26 10:19:25,020 ERROR [io.qua.run.Application] (main) Failed to start application: java.lang.RuntimeException: Failed to start quarkus
Caused by: java.lang.AssertionError: The namespace of Azure Event Hubs must be set
```
With this PR, running the jar without assertions enabled results in:
```text
The namespace of Azure Event Hubs must be set
```
Reproducer: [code-with-quarkus.zip](https://github.com/user-attachments/files/20437959/code-with-quarkus.zip)
