### PR TITLE
The servicebus extension can produce ServiceBusClientBuilder instances

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus.adoc
@@ -1,0 +1,95 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-enabled[`quarkus.azure.servicebus.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The flag to enable the extension. If set to false, the CDI producers will be disabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-azure-servicebus_quarkus-azure-servicebus-connection-string]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-connection-string[`quarkus.azure.servicebus.connection-string`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.connection-string+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Connect to the Service Bus using this connection string. If set, authentication is handled by the SAS key in the connection string. Otherwise, a DefaultAzureCredentialBuilder will be used for authentication, and namespace and domain have to be configured.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_CONNECTION_STRING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_CONNECTION_STRING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-azure-servicebus_quarkus-azure-servicebus-namespace]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-namespace[`quarkus.azure.servicebus.namespace`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.namespace+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The namespace of the Service Bus.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_NAMESPACE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_NAMESPACE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-azure-servicebus_quarkus-azure-servicebus-domain-name]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-domain-name[`quarkus.azure.servicebus.domain-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.domain-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The domain name of the Service Bus.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DOMAIN_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DOMAIN_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`servicebus.windows.net`
+
+|===
+

--- a/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus_quarkus.azure.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus_quarkus.azure.adoc
@@ -1,0 +1,95 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-enabled[`quarkus.azure.servicebus.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The flag to enable the extension. If set to false, the CDI producers will be disabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-azure-servicebus_quarkus-azure-servicebus-connection-string]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-connection-string[`quarkus.azure.servicebus.connection-string`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.connection-string+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Connect to the Service Bus using this connection string. If set, authentication is handled by the SAS key in the connection string. Otherwise, a DefaultAzureCredentialBuilder will be used for authentication, and namespace and domain have to be configured.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_CONNECTION_STRING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_CONNECTION_STRING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-azure-servicebus_quarkus-azure-servicebus-namespace]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-namespace[`quarkus.azure.servicebus.namespace`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.namespace+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The namespace of the Service Bus.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_NAMESPACE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_NAMESPACE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-azure-servicebus_quarkus-azure-servicebus-domain-name]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-domain-name[`quarkus.azure.servicebus.domain-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.domain-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The domain name of the Service Bus.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DOMAIN_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DOMAIN_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`servicebus.windows.net`
+
+|===
+

--- a/services/azure-servicebus/deployment/pom.xml
+++ b/services/azure-servicebus/deployment/pom.xml
@@ -29,6 +29,11 @@
             <groupId>io.quarkiverse.azureservices</groupId>
             <artifactId>quarkus-azure-servicebus</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusProcessor.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusProcessor.java
@@ -1,9 +1,15 @@
+package io.quarkiverse.azure.servicebus.deployment;
+
 import java.util.stream.Stream;
 
+import io.quarkiverse.azure.servicebus.runtime.ServiceBusBuildTimeConfig;
+import io.quarkiverse.azure.servicebus.runtime.ServiceBusClientProducer;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
 public class ServiceBusProcessor {
@@ -16,8 +22,21 @@ public class ServiceBusProcessor {
     }
 
     @BuildStep
+    AdditionalBeanBuildItem producer(ServiceBusBuildTimeConfig config) {
+        if (config.enabled()) {
+            return new AdditionalBeanBuildItem(ServiceBusClientProducer.class);
+        }
+        return null;
+    }
+
+    @BuildStep
     ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
         return new ExtensionSslNativeSupportBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    IndexDependencyBuildItem indexDependency() {
+        return new IndexDependencyBuildItem("com.azure", "azure-messaging-servicebus");
     }
 
     @BuildStep

--- a/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/DisabledDeploymentTest.java
+++ b/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/DisabledDeploymentTest.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.azure.servicebus.deployment;
+
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.azure.messaging.servicebus.ServiceBusClientBuilder;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class DisabledDeploymentTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setExpectedException(UnsatisfiedResolutionException.class)
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset("quarkus.azure.servicebus.enabled=false"), "application.properties"));
+
+    @Inject
+    ServiceBusClientBuilder serviceBusClientBuilder;
+
+    @Test
+    void disabledCdiProducersLetDeploymentFail() {
+
+    }
+}

--- a/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/EnabledDeploymentTest.java
+++ b/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/EnabledDeploymentTest.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.azure.servicebus.deployment;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.azure.messaging.servicebus.ServiceBusClientBuilder;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class EnabledDeploymentTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(
+                            "quarkus.azure.servicebus.connection-string=Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;"),
+                            "application.properties"));
+
+    @Inject
+    ServiceBusClientBuilder serviceBusClientBuilder;
+
+    @Test
+    void cdiProducerWorks() {
+
+    }
+}

--- a/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusBuildTimeConfig.java
+++ b/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusBuildTimeConfig.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.azure.servicebus.runtime;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_AND_RUN_TIME_FIXED;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.azure.servicebus")
+@ConfigRoot(phase = BUILD_AND_RUN_TIME_FIXED)
+public interface ServiceBusBuildTimeConfig {
+
+    /**
+     * The flag to enable the extension.
+     * If set to false, the CDI producers will be disabled.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+}

--- a/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java
+++ b/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.azure.servicebus.runtime;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.messaging.servicebus.ServiceBusClientBuilder;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+
+public class ServiceBusClientProducer {
+
+    @Inject
+    ServiceBusConfig config;
+
+    @Produces
+    ServiceBusClientBuilder produceServiceBusClientBuilder() {
+        if (config.connectionString().isPresent()) {
+            return new ServiceBusClientBuilder()
+                    .connectionString(config.connectionString().get());
+        }
+
+        String namespace = config.namespace()
+                .orElseThrow(() -> new ConfigurationException(
+                        "Either the connection string (quarkus.azure.servicebus.connection-string) or the namespace (quarkus.azure.servicebus.namespace) must be set."));
+
+        return new ServiceBusClientBuilder()
+                .fullyQualifiedNamespace(namespace + "." + config.domainName())
+                .credential(new DefaultAzureCredentialBuilder().build());
+    }
+}

--- a/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusConfig.java
+++ b/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusConfig.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.azure.servicebus.runtime;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.azure.servicebus")
+@ConfigRoot(phase = RUN_TIME)
+public interface ServiceBusConfig {
+
+    /**
+     * Connect to the Service Bus using this connection string.
+     * If set, authentication is handled by the SAS key in the connection string.
+     * Otherwise, a DefaultAzureCredentialBuilder will be used for authentication,
+     * and namespace and domain have to be configured.
+     */
+    Optional<String> connectionString();
+
+    /**
+     * The namespace of the Service Bus.
+     */
+    Optional<String> namespace();
+
+    /**
+     * The domain name of the Service Bus.
+     */
+    @WithDefault("servicebus.windows.net")
+    String domainName();
+}


### PR DESCRIPTION
Notes for the reviewer:
- I put `quarkus.azure.servicebus.enabled` in a separate build time configuration so that I can selectively include the CDI producer.
This allows the user of the extension to use his own producers while still benefiting from the module's native image compilation support.
- I included the property names in the error messages so that they become more helpful.