### PR TITLE
Consistency: Include property names in configuration error messagesError messages

### DIFF
--- a/services/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfig.java
+++ b/services/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfig.java
@@ -40,7 +40,8 @@ public interface AzureAppConfigurationConfig {
             return "";
         }
         String endpoint = endpoint()
-                .orElseThrow(() -> new ConfigurationException("The endpoint of the app configuration must be set"));
+                .orElseThrow(() -> new ConfigurationException(
+                        "The endpoint of the app configuration (quarkus.azure.app.configuration.endpoint) must be set"));
 
         if (id().isEmpty() || secret().isEmpty()) {
             return "";

--- a/services/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
+++ b/services/azure-app-configuration/runtime/src/main/java/io/quarkiverse/azure/app/configuration/AzureAppConfigurationConfigSourceFactory.java
@@ -47,7 +47,8 @@ public class AzureAppConfigurationConfigSourceFactory
             return Collections.emptyMap();
         }
         String endpoint = config.endpoint()
-                .orElseThrow(() -> new ConfigurationException("The endpoint of the app configuration must be set"));
+                .orElseThrow(() -> new ConfigurationException(
+                        "The endpoint of the app configuration (quarkus.azure.app.configuration.endpoint) must be set"));
 
         // We cannot use the Quarkus Vert.x instance, because the configuration executes before starting Vert.x
         Vertx vertx = Vertx.vertx();

--- a/services/azure-cosmos/runtime/src/main/java/io/quarkiverse/azure/cosmos/runtime/CosmosClientProducer.java
+++ b/services/azure-cosmos/runtime/src/main/java/io/quarkiverse/azure/cosmos/runtime/CosmosClientProducer.java
@@ -27,7 +27,8 @@ public class CosmosClientProducer {
         }
 
         String endpoint = cosmosConfiguration.endpoint()
-                .orElseThrow(() -> new ConfigurationException("The endpoint of Azure Cosmos DB must be set"));
+                .orElseThrow(() -> new ConfigurationException(
+                        "The endpoint of Azure Cosmos DB (quarkus.azure.cosmos.endpoint) must be set"));
         CosmosClientBuilder builder = new CosmosClientBuilder()
                 .userAgentSuffix(AzureQuarkusIdentifier.AZURE_QUARKUS_COSMOS)
                 .endpoint(endpoint);

--- a/services/azure-eventhubs/runtime/src/main/java/io/quarkiverse/azure/eventhubs/runtime/EventhubsClientProducer.java
+++ b/services/azure-eventhubs/runtime/src/main/java/io/quarkiverse/azure/eventhubs/runtime/EventhubsClientProducer.java
@@ -73,11 +73,14 @@ public class EventhubsClientProducer {
         }
 
         String namespace = eventhubsConfig.namespace()
-                .orElseThrow(() -> new ConfigurationException("The namespace of Azure Event Hubs must be set"));
+                .orElseThrow(() -> new ConfigurationException(
+                        "The namespace of Azure Event Hubs (quarkus.azure.eventhubs.namespace) must be set"));
         String domainName = eventhubsConfig.domainName()
-                .orElseThrow(() -> new ConfigurationException("The domain name of Azure Event Hubs must be set"));
+                .orElseThrow(() -> new ConfigurationException(
+                        "The domain name of Azure Event Hubs (quarkus.azure.eventhubs.domain-name) must be set"));
         String eventhubName = eventhubsConfig.eventhubName()
-                .orElseThrow(() -> new ConfigurationException("The event hub name of Azure Event Hubs must be set"));
+                .orElseThrow(() -> new ConfigurationException(
+                        "The event hub name of Azure Event Hubs (quarkus.azure.eventhubs.eventhub-name) must be set"));
         return new EventHubClientBuilder()
                 .clientOptions(new ClientOptions().setApplicationId(AzureQuarkusIdentifier.AZURE_QUARKUS_EVENTHUBS))
                 .credential(namespace + "." + domainName,

--- a/services/azure-keyvault/runtime/src/main/java/io/quarkiverse/azure/keyvault/secret/runtime/KeyVaultSecretClientProducer.java
+++ b/services/azure-keyvault/runtime/src/main/java/io/quarkiverse/azure/keyvault/secret/runtime/KeyVaultSecretClientProducer.java
@@ -25,7 +25,8 @@ public class KeyVaultSecretClientProducer {
         }
 
         String endpoint = secretConfiguration.endpoint()
-                .orElseThrow(() -> new ConfigurationException("The endpoint of Azure Key Vault Secret must be set"));
+                .orElseThrow(() -> new ConfigurationException(
+                        "The endpoint of Azure Key Vault Secret (quarkus.azure.keyvault.secret.endpoint) must be set"));
         return new SecretClientBuilder()
                 .clientOptions(new ClientOptions().setApplicationId(AzureQuarkusIdentifier.AZURE_QUARKUS_KEY_VAULT_SYNC_CLIENT))
                 .vaultUrl(endpoint)

--- a/services/azure-keyvault/runtime/src/main/java/io/quarkiverse/azure/keyvault/secret/runtime/config/KeyVaultSecretConfigUtil.java
+++ b/services/azure-keyvault/runtime/src/main/java/io/quarkiverse/azure/keyvault/secret/runtime/config/KeyVaultSecretConfigUtil.java
@@ -82,10 +82,12 @@ public class KeyVaultSecretConfigUtil {
 
     static String getAzureKeyVaultName(String endpoint) {
         if (endpoint.isEmpty()) {
-            throw new ConfigurationException("The endpoint of Azure Key Vault should be set.");
+            throw new ConfigurationException(
+                    "The endpoint of Azure Key Vault (quarkus.azure.keyvault.secret.endpoint) should be set.");
         }
         if (!endpoint.startsWith(AZURE_KEYVAULT_ENDPOINT_PREFIX)) {
-            throw new ConfigurationException("The endpoint of Azure Key Vault should start with https://.");
+            throw new ConfigurationException(
+                    "The endpoint of Azure Key Vault (quarkus.azure.keyvault.secret.endpoint) should start with https://.");
         }
         return endpoint.substring(AZURE_KEYVAULT_ENDPOINT_PREFIX.length()).split("\\.")[0];
     }

--- a/services/azure-keyvault/runtime/src/main/java/io/quarkiverse/azure/keyvault/secret/runtime/config/KeyVaultSecretConfigUtil.java
+++ b/services/azure-keyvault/runtime/src/main/java/io/quarkiverse/azure/keyvault/secret/runtime/config/KeyVaultSecretConfigUtil.java
@@ -15,13 +15,12 @@ public class KeyVaultSecretConfigUtil {
 
     /**
      *
-     * @returns a {@link KeyvaultSecretIdentifier} from the specified input or <code>null</code> if the input does not start
-     *          with {@link AZURE_KEYVAULT_PREFIX}.
+     * @returns a {@link KeyVaultSecretIdentifier} from the specified input or <code>null</code> if the input does not start
+     *          with {@link #AZURE_KEYVAULT_PREFIX}.
      *
      * @throws IllegalArgumentException if the input cannot otherwise be parsed.
      *
      */
-
     static KeyVaultSecretIdentifier getSecretIdentifier(String input, String defaultEndpoint) {
 
         if (!input.startsWith(AZURE_KEYVAULT_PREFIX)) {

--- a/services/azure-storage-blob/runtime/src/main/java/io/quarkiverse/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
+++ b/services/azure-storage-blob/runtime/src/main/java/io/quarkiverse/azure/storage/blob/runtime/StorageBlobServiceClientProducer.java
@@ -35,7 +35,8 @@ public class StorageBlobServiceClientProducer {
         }
 
         if (storageBlobConfiguration.endpoint().isEmpty() && storageBlobConfiguration.connectionString().isEmpty()) {
-            throw new ConfigurationException("The endpoint or connection string of Azure Storage blob must be set");
+            throw new ConfigurationException(
+                    "The endpoint (quarkus.azure.storage.blob.endpoint) or connection string (quarkus.azure.storage.blob.connection-string) of Azure Storage blob must be set");
         }
 
         BlobServiceClientBuilder builder = new BlobServiceClientBuilder()


### PR DESCRIPTION
#391 introduced property names in the config error messages. This PR adjusts the remaining error messages to be consistent.