### PR TITLE
Cleanup and fix AssertionError for Azure Event Hubs integration tests

### DIFF
--- a/integration-tests/azure-eventhubs/src/main/java/io/quarkiverse/azure/eventhubs/it/EventhubsAsyncResource.java
+++ b/integration-tests/azure-eventhubs/src/main/java/io/quarkiverse/azure/eventhubs/it/EventhubsAsyncResource.java
@@ -30,7 +30,7 @@ public class EventhubsAsyncResource {
     @Path("/sendEvents")
     @GET
     public void sendEvents() throws InterruptedException {
-        List<EventData> allEvents = List.of(new EventData("Foobar-Asyn-1"), new EventData("Foobar-Asyn-2"));
+        List<EventData> allEvents = List.of(new EventData("Foobar-Asyn-0"), new EventData("Foobar-Asyn-1"));
         // Creating a batch without options set, will allow for automatic routing of events to any partition.
         producer.send(allEvents, new SendOptions().setPartitionId("1"))
                 .subscribe(unused -> {
@@ -57,10 +57,11 @@ public class EventhubsAsyncResource {
                     EventData event = partitionEvent.getData();
 
                     Long sequenceNumber = event.getSequenceNumber();
-                    assert event.getBodyAsString().equals("Foobar-Asyn-" + sequenceNumber);
                     LOGGER.info("Received event from partition:: " + partitionContext.getPartitionId());
                     LOGGER.info("Event Body is:: " + event.getBodyAsString());
                     LOGGER.info("SequenceNumber is:: " + sequenceNumber);
+                    // Note: sequenceNumber % 2 handles the case where multiple test runs accumulate events
+                    assert event.getBodyAsString().equals("Foobar-Asyn-" + (sequenceNumber % 2));
 
                 }, error -> {
                     // This is a terminal signal.  No more events will be received from the same Flux object.

--- a/integration-tests/azure-eventhubs/src/test/java/io/quarkiverse/azure/eventhubs/it/EventHubsAsyncResourceIT.java
+++ b/integration-tests/azure-eventhubs/src/test/java/io/quarkiverse/azure/eventhubs/it/EventHubsAsyncResourceIT.java
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 @EnabledIfSystemProperty(named = "azure.test", matches = "true")
-public class EventHubsAsyncResourceIT extends EventHubsResourceTest {
+public class EventHubsAsyncResourceIT extends EventHubsAsyncResourceTest {
 }

--- a/services/azure-cosmos/deployment/src/main/java/io/quarkiverse/azure/cosmos/deployment/CosmosProcessor.java
+++ b/services/azure-cosmos/deployment/src/main/java/io/quarkiverse/azure/cosmos/deployment/CosmosProcessor.java
@@ -60,6 +60,7 @@ public class CosmosProcessor {
                 com.azure.cosmos.implementation.RetryContext.class.getName(),
                 com.azure.cosmos.implementation.circuitBreaker.PartitionLevelCircuitBreakerConfig.class.getName(),
                 "com.azure.cosmos.implementation.ClientSideRequestStatistics$StoreResponseStatistics",
+                "com.azure.cosmos.implementation.routing.PartitionKeyInternal$PartitionKeyInternalJsonSerializer",
                 com.azure.cosmos.models.PartitionKeyDefinition.class.getName(),
                 com.azure.cosmos.models.PartitionKind.class.getName(),
                 com.azure.cosmos.models.UniqueKeyPolicy.class.getName(),

--- a/services/azure-cosmos/deployment/src/main/java/io/quarkiverse/azure/cosmos/deployment/CosmosProcessor.java
+++ b/services/azure-cosmos/deployment/src/main/java/io/quarkiverse/azure/cosmos/deployment/CosmosProcessor.java
@@ -8,7 +8,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
@@ -29,11 +28,6 @@ public class CosmosProcessor {
     @BuildStep
     ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
         return new ExtensionSslNativeSupportBuildItem(FEATURE);
-    }
-
-    @BuildStep
-    IndexDependencyBuildItem indexDependency() {
-        return new IndexDependencyBuildItem("com.azure", "azure-cosmos");
     }
 
     @BuildStep

--- a/services/azure-eventhubs/deployment/src/main/java/io/quarkiverse/azure/eventhubs/deployment/EventhubsProcessor.java
+++ b/services/azure-eventhubs/deployment/src/main/java/io/quarkiverse/azure/eventhubs/deployment/EventhubsProcessor.java
@@ -32,7 +32,6 @@ public class EventhubsProcessor {
     @BuildStep
     void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClasses) {
         Stream.of(
-                "reactor.netty.tcp.TcpClientSecure",
                 "com.azure.messaging.eventhubs.PartitionBasedLoadBalancer",
                 "com.microsoft.azure.proton.transport.proxy.impl.DigestProxyChallengeProcessorImpl",
                 "com.microsoft.azure.proton.transport.ws.impl.Utils")

--- a/services/azure-eventhubs/deployment/src/main/java/io/quarkiverse/azure/eventhubs/deployment/EventhubsProcessor.java
+++ b/services/azure-eventhubs/deployment/src/main/java/io/quarkiverse/azure/eventhubs/deployment/EventhubsProcessor.java
@@ -8,7 +8,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
 public class EventhubsProcessor {
@@ -28,11 +27,6 @@ public class EventhubsProcessor {
     @BuildStep
     ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
         return new ExtensionSslNativeSupportBuildItem(FEATURE);
-    }
-
-    @BuildStep
-    IndexDependencyBuildItem indexDependency() {
-        return new IndexDependencyBuildItem("com.azure", "azure-eventhubs");
     }
 
     @BuildStep

--- a/services/azure-eventhubs/runtime/pom.xml
+++ b/services/azure-eventhubs/runtime/pom.xml
@@ -32,10 +32,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.projectreactor.netty</groupId>
-            <artifactId>reactor-netty-http</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>


### PR DESCRIPTION
This pull request includes updates to the Azure Event Hubs and Cosmos integrations, focusing on test adjustments, dependency cleanup, and runtime configuration improvements. The most significant changes involve modifying test logic for event handling, removing unused dependencies, and adding reflective class support for Cosmos.

### Event Hubs Integration Changes:
* Updated the `sendEvents` method in `EventhubsAsyncResource` to include a new event (`Foobar-Asyn-0`) in the test data.
* Adjusted the `receiveEvents` method in `EventhubsAsyncResource` to account for sequence number modulo logic to handle accumulated events across test runs.
* Fixed a typo in the test class inheritance by changing `EventHubsAsyncResourceIT` to extend `EventHubsAsyncResourceTest` instead of `EventHubsResourceTest`.

### Cosmos Integration Changes:
* Removed the `IndexDependencyBuildItem` for `azure-cosmos` in `CosmosProcessor` as it is no longer required. [[1]](diffhunk://#diff-f59bf70f0c0a8893cf863a9b8373a97583b54706d38c3bc0bea2539d048e1890L11) [[2]](diffhunk://#diff-f59bf70f0c0a8893cf863a9b8373a97583b54706d38c3bc0bea2539d048e1890L34-L38)
* Added a reflective class entry for `PartitionKeyInternal$PartitionKeyInternalJsonSerializer` in `CosmosProcessor` to support runtime initialization.

### General Dependency Cleanup:
* Removed the `IndexDependencyBuildItem` for `azure-eventhubs` in `EventhubsProcessor` and cleaned up unused classes like `reactor.netty.tcp.TcpClientSecure`. [[1]](diffhunk://#diff-8149420e79678e8f4d8988980f7cca2faeb124f9030cb6184c882f204bff3827L11) [[2]](diffhunk://#diff-8149420e79678e8f4d8988980f7cca2faeb124f9030cb6184c882f204bff3827L33-L41)
* Eliminated the `reactor-netty-http` dependency from the `azure-eventhubs` runtime `pom.xml`.