### PR TITLE
Add Service Bus Dev Services

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus.adoc
@@ -17,12 +17,37 @@ endif::add-copy-button-to-config-props[]
 --
 The flag to enable the extension. If set to false, the CDI producers will be disabled.
 
+This flag does not affect Dev Services. To disable Dev Services, you must explicitly set either `quarkus.azure.servicebus.devservices.enabled` or `quarkus.devservices.enabled` to `false`.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled[`quarkus.azure.servicebus.devservices.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.devservices.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If the Dev Services have been explicitly enabled or disabled. Dev Services are generally enabled by default.
+
+When Dev Services are enabled, Quarkus will attempt to automatically configure and start an Azure Service Bus emulator instance when running in Dev or Test mode and when Docker is running. `quarkus.azure.servicebus.connection-string` will be set to point to the emulator.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -57,7 +82,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The namespace of the Service Bus.
+The namespace of the Service Bus. The domain name is appended to this value to form the fully qualified namespace name.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -78,7 +103,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The domain name of the Service Bus.
+The domain name of the Service Bus. The domain name is appended to the namespace to form the fully qualified namespace name.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus.adoc
@@ -7,6 +7,50 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled[`quarkus.azure.servicebus.devservices.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.devservices.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether Dev Services should be enabled or not. Dev Services are enabled by default unless a specific Azure Service Bus connection exists.
+
+When Dev Services are enabled, Quarkus will attempt to automatically configure and start an Azure Service Bus emulator instance and an associated MSSQL Server when running in dev or test mode and when Docker is running. `quarkus.azure.servicebus.connection-string` will be set to point to the emulator.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-licence-accepted]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-licence-accepted[`quarkus.azure.servicebus.devservices.licence-accepted`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.devservices.licence-accepted+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+To use the Service Bus Dev Services, you must accept the license terms of the Service Bus emulator and the Microsoft SQL Server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_LICENCE_ACCEPTED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_LICENCE_ACCEPTED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-enabled[`quarkus.azure.servicebus.enabled`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.azure.servicebus.enabled+++[]
@@ -25,29 +69,6 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_ENABL
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---
-|boolean
-|`true`
-
-a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled[`quarkus.azure.servicebus.devservices.enabled`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.azure.servicebus.devservices.enabled+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-If the Dev Services have been explicitly enabled or disabled. Dev Services are generally enabled by default.
-
-When Dev Services are enabled, Quarkus will attempt to automatically configure and start an Azure Service Bus emulator instance when running in Dev or Test mode and when Docker is running. `quarkus.azure.servicebus.connection-string` will be set to point to the emulator.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus_quarkus.azure.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus_quarkus.azure.adoc
@@ -17,12 +17,37 @@ endif::add-copy-button-to-config-props[]
 --
 The flag to enable the extension. If set to false, the CDI producers will be disabled.
 
+This flag does not affect Dev Services. To disable Dev Services, you must explicitly set either `quarkus.azure.servicebus.devservices.enabled` or `quarkus.devservices.enabled` to `false`.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled[`quarkus.azure.servicebus.devservices.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.devservices.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If the Dev Services have been explicitly enabled or disabled. Dev Services are generally enabled by default.
+
+When Dev Services are enabled, Quarkus will attempt to automatically configure and start an Azure Service Bus emulator instance when running in Dev or Test mode and when Docker is running. `quarkus.azure.servicebus.connection-string` will be set to point to the emulator.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -57,7 +82,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The namespace of the Service Bus.
+The namespace of the Service Bus. The domain name is appended to this value to form the fully qualified namespace name.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -78,7 +103,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The domain name of the Service Bus.
+The domain name of the Service Bus. The domain name is appended to the namespace to form the fully qualified namespace name.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus_quarkus.azure.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus_quarkus.azure.adoc
@@ -7,6 +7,50 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled[`quarkus.azure.servicebus.devservices.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.devservices.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether Dev Services should be enabled or not. Dev Services are enabled by default unless a specific Azure Service Bus connection exists.
+
+When Dev Services are enabled, Quarkus will attempt to automatically configure and start an Azure Service Bus emulator instance and an associated MSSQL Server when running in dev or test mode and when Docker is running. `quarkus.azure.servicebus.connection-string` will be set to point to the emulator.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-licence-accepted]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-licence-accepted[`quarkus.azure.servicebus.devservices.licence-accepted`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.devservices.licence-accepted+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+To use the Service Bus Dev Services, you must accept the license terms of the Service Bus emulator and the Microsoft SQL Server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_LICENCE_ACCEPTED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_LICENCE_ACCEPTED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-enabled[`quarkus.azure.servicebus.enabled`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.azure.servicebus.enabled+++[]
@@ -25,29 +69,6 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_ENABL
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---
-|boolean
-|`true`
-
-a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-enabled[`quarkus.azure.servicebus.devservices.enabled`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.azure.servicebus.devservices.enabled+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-If the Dev Services have been explicitly enabled or disabled. Dev Services are generally enabled by default.
-
-When Dev Services are enabled, Quarkus will attempt to automatically configure and start an Azure Service Bus emulator instance when running in Dev or Test mode and when Docker is running. `quarkus.azure.servicebus.connection-string` will be set to point to the emulator.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/quarkus-azure-servicebus.adoc
+++ b/docs/modules/ROOT/pages/quarkus-azure-servicebus.adoc
@@ -5,7 +5,12 @@ include::./includes/attributes.adoc[]
 include::./includes/support.adoc[]
 
 https://azure.microsoft.com/products/service-bus[Azure Service Bus] is a fully managed enterprise message broker with message queues and publish-subscribe topics. Service Bus is used to decouple applications and services from each other. 
-This extension allows you to produce and consume messages from Azure Service Bus by creating Service Bus clients with injected `com.azure.messaging.servicebus.ServiceBusClientBuilder` objects in your Quarkus application.
+
+This extension provides the following benefits:
+
+- It resolves native build issues so that applications using the Azure Service Bus with the Azure SDK for Java can be compiled to a native image.
+- It injects `com.azure.messaging.servicebus.ServiceBusClientBuilder` instances that can be used to create clients for an Azure Service Bus that send and consume messages.
+- The dev services launch an Azure Service Bus emulator in dev and test mode and configure the injected builders to use it.
 
 This is a step by step guide on how to use the Quarkus Azure Service Bus extension. If you're looking for a complete code sample, you can find it in the https://github.com/quarkiverse/quarkus-azure-services/tree/main/integration-tests/azure-servicebus[Azure Service Bus sample].
 

--- a/integration-tests/azure-servicebus/src/main/resources/application.properties
+++ b/integration-tests/azure-servicebus/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.azure.servicebus.devservices.enabled=false

--- a/services/azure-servicebus/deployment/pom.xml
+++ b/services/azure-servicebus/deployment/pom.xml
@@ -26,8 +26,22 @@
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.azureservices</groupId>
             <artifactId>quarkus-azure-servicebus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>azure</artifactId>
+        </dependency>
+        <dependency>
+            <!-- required by the underlying Testcontainers library for checking readiness
+             of the MSSQL database container used by the Azure Service Bus emulator -->
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusBuildTimeConfig.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusBuildTimeConfig.java
@@ -20,9 +20,4 @@ public interface ServiceBusBuildTimeConfig {
     @WithDefault("true")
     boolean enabled();
 
-    /**
-     * Dev Services configuration.
-     */
-    ServiceBusDevServicesConfig devservices();
-
 }

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusBuildTimeConfig.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusBuildTimeConfig.java
@@ -1,13 +1,11 @@
-package io.quarkiverse.azure.servicebus.runtime;
-
-import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_AND_RUN_TIME_FIXED;
+package io.quarkiverse.azure.servicebus.deployment;
 
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
+@ConfigRoot
 @ConfigMapping(prefix = "quarkus.azure.servicebus")
-@ConfigRoot(phase = BUILD_AND_RUN_TIME_FIXED)
 public interface ServiceBusBuildTimeConfig {
 
     /**

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusBuildTimeConfig.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusBuildTimeConfig.java
@@ -11,8 +11,18 @@ public interface ServiceBusBuildTimeConfig {
     /**
      * The flag to enable the extension.
      * If set to false, the CDI producers will be disabled.
+     * <p>
+     * This flag does not affect Dev Services.
+     * To disable Dev Services, you must explicitly set either
+     * {@code quarkus.azure.servicebus.devservices.enabled}
+     * or {@code quarkus.devservices.enabled} to {@code false}.
      */
     @WithDefault("true")
     boolean enabled();
+
+    /**
+     * Dev Services configuration.
+     */
+    ServiceBusDevServicesConfig devservices();
 
 }

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesConfig.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesConfig.java
@@ -1,32 +1,57 @@
 package io.quarkiverse.azure.servicebus.deployment;
 
+import static io.quarkiverse.azure.servicebus.deployment.ServiceBusDevServicesConfig.PREFIX;
+
 import java.util.function.BooleanSupplier;
 
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
+@ConfigRoot
+@ConfigMapping(prefix = PREFIX)
 public interface ServiceBusDevServicesConfig {
+    String PREFIX = "quarkus.azure.servicebus.devservices";
 
     /**
-     * If the Dev Services have been explicitly enabled or disabled.
-     * Dev Services are generally enabled by default.
+     * The name of the property to enable or disable the DevServices.
+     */
+    String CONFIG_KEY_DEVSERVICE_ENABLED = PREFIX + ".enabled";
+
+    /**
+     * The name of the property to accept the EULA of Azure Service Bus emulator and MSSQL Server.
+     */
+    String CONFIG_KEY_LICENCE_ACCEPTED = PREFIX + ".licence-accepted";
+
+    /**
+     * Whether Dev Services should be enabled or not.
+     * Dev Services are enabled by default unless a specific Azure Service Bus connection exists.
      * <p>
      * When Dev Services are enabled, Quarkus will attempt to automatically configure and start
-     * an Azure Service Bus emulator instance when running in Dev or Test mode and when Docker is running.
+     * an Azure Service Bus emulator instance and an associated MSSQL Server when running in dev
+     * or test mode and when Docker is running.
      * {@code quarkus.azure.servicebus.connection-string} will be set to point to the emulator.
      */
     @WithDefault("true")
     boolean enabled();
 
-    class Enabled implements BooleanSupplier {
-        final ServiceBusBuildTimeConfig config;
+    /**
+     * To use the Service Bus Dev Services, you must accept the license terms of the Service Bus emulator and the Microsoft SQL
+     * Server.
+     */
+    @WithDefault("false")
+    boolean licenceAccepted();
 
-        public Enabled(ServiceBusBuildTimeConfig config) {
+    class Enabled implements BooleanSupplier {
+        final ServiceBusDevServicesConfig config;
+
+        public Enabled(ServiceBusDevServicesConfig config) {
             this.config = config;
         }
 
         @Override
         public boolean getAsBoolean() {
-            return config.devservices().enabled();
+            return config.enabled();
         }
     }
 

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesConfig.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesConfig.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.azure.servicebus.deployment;
+
+import java.util.function.BooleanSupplier;
+
+import io.smallrye.config.WithDefault;
+
+public interface ServiceBusDevServicesConfig {
+
+    /**
+     * If the Dev Services have been explicitly enabled or disabled.
+     * Dev Services are generally enabled by default.
+     * <p>
+     * When Dev Services are enabled, Quarkus will attempt to automatically configure and start
+     * an Azure Service Bus emulator instance when running in Dev or Test mode and when Docker is running.
+     * {@code quarkus.azure.servicebus.connection-string} will be set to point to the emulator.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    class Enabled implements BooleanSupplier {
+        final ServiceBusBuildTimeConfig config;
+
+        public Enabled(ServiceBusBuildTimeConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public boolean getAsBoolean() {
+            return config.devservices().enabled();
+        }
+    }
+
+}

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesProcessor.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesProcessor.java
@@ -1,0 +1,85 @@
+package io.quarkiverse.azure.servicebus.deployment;
+
+import static io.quarkiverse.azure.servicebus.deployment.ServiceBusProcessor.FEATURE;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.testcontainers.azure.ServiceBusEmulatorContainer;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.MountableFile;
+
+import io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig;
+import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.runtime.configuration.ConfigurationException;
+
+public class ServiceBusDevServicesProcessor {
+
+    private static final String EMULATOR_CONFIG_FILE = "servicebus-config.json";
+    static volatile List<RunningDevService> devServices;
+
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { DevServicesConfig.Enabled.class,
+            ServiceBusDevServicesConfig.Enabled.class })
+    public List<DevServicesResultBuildItem> startServiceBusEmulator(BuildProducer<ValidationErrorBuildItem> configErrors) {
+        if (isInvalidConfiguration(configErrors)) {
+            return null;
+        }
+
+        if (devServices == null) {
+            devServices = startContainers();
+        }
+
+        return devServices.stream()
+                .map(RunningDevService::toBuildItem)
+                .toList();
+    }
+
+    private static boolean isInvalidConfiguration(BuildProducer<ValidationErrorBuildItem> configErrors) {
+        if (isEmulatorConfigFileMissing()) {
+            configErrors.produce(new ValidationErrorBuildItem(new ConfigurationException(
+                    "The Service Bus emulator configuration file was not found at 'src/main/resources/%s'."
+                            .formatted(EMULATOR_CONFIG_FILE))));
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isEmulatorConfigFileMissing() {
+        URL resourceUrl = Thread.currentThread().getContextClassLoader().getResource(EMULATOR_CONFIG_FILE);
+        return resourceUrl == null;
+    }
+
+    private List<RunningDevService> startContainers() {
+        Network internalNetwork = Network.newNetwork();
+
+        MSSQLServerContainer<?> database = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
+                .acceptLicense()
+                .withNetwork(internalNetwork);
+
+        ServiceBusEmulatorContainer emulator = new ServiceBusEmulatorContainer(
+                "mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2")
+                .acceptLicense()
+                .withConfig(MountableFile.forClasspathResource(EMULATOR_CONFIG_FILE))
+                .withMsSqlServerContainer(database)
+                .withNetwork(internalNetwork);
+
+        emulator.start();
+
+        Map<String, String> configOverrides = Map.of(ServiceBusConfig.CONNECTION_STRING, emulator.getConnectionString());
+
+        RunningDevService databaseDevService = new RunningDevService(FEATURE, database.getContainerId(), database::close,
+                Collections.emptyMap());
+        RunningDevService emulatorDevService = new RunningDevService(FEATURE, emulator.getContainerId(), emulator::close,
+                configOverrides);
+        return List.of(databaseDevService, emulatorDevService);
+    }
+}

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusProcessor.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusProcessor.java
@@ -2,7 +2,6 @@ package io.quarkiverse.azure.servicebus.deployment;
 
 import java.util.stream.Stream;
 
-import io.quarkiverse.azure.servicebus.runtime.ServiceBusBuildTimeConfig;
 import io.quarkiverse.azure.servicebus.runtime.ServiceBusClientProducer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;

--- a/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/DeploymentWithDevServicesTest.java
+++ b/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/DeploymentWithDevServicesTest.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.azure.servicebus.deployment;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * If no Service Bus connection was configured, the Dev Services start an
+ * Azure Service Bus Emulator and set the connection string to point to it.
+ */
+class DeploymentWithDevServicesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(
+                            new StringAsset(
+                                    """
+                                            # We do not set a connection string. This triggers the Dev Services.
+
+                                            quarkus.azure.servicebus.devservices.licence-accepted=true
+                                            """),
+                            "application.properties")
+                    .addAsResource("minimal-servicebus-config.json", "servicebus-config.json"));
+
+    @ConfigProperty(name = ServiceBusConfig.CONFIG_KEY_CONNECTION_STRING)
+    String connectionString;
+
+    @Test
+    void theConnectionStringPointsToTheEmulator() {
+        assertThat(connectionString, containsString("UseDevelopmentEmulator=true"));
+    }
+}

--- a/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/DeploymentWithDisabledProducersTest.java
+++ b/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/DeploymentWithDisabledProducersTest.java
@@ -11,13 +11,21 @@ import com.azure.messaging.servicebus.ServiceBusClientBuilder;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-class DisabledDeploymentTest {
+class DeploymentWithDisabledProducersTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setExpectedException(UnsatisfiedResolutionException.class)
             .withApplicationRoot((jar) -> jar
-                    .addAsResource(new StringAsset("quarkus.azure.servicebus.enabled=false"), "application.properties"));
+                    .addAsResource(
+                            new StringAsset(
+                                    """
+                                            # disable the CDI producers of the extension
+                                            quarkus.azure.servicebus.enabled=false
+                                            # disable the Dev Services to avoid potential configuration issues to interfere with the injection tests
+                                            quarkus.azure.servicebus.devservices.enabled=false
+                                            """),
+                            "application.properties"));
 
     @Inject
     ServiceBusClientBuilder serviceBusClientBuilder;

--- a/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/DeploymentWithEnabledProducersTest.java
+++ b/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/DeploymentWithEnabledProducersTest.java
@@ -10,13 +10,19 @@ import com.azure.messaging.servicebus.ServiceBusClientBuilder;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-class EnabledDeploymentTest {
+class DeploymentWithEnabledProducersTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addAsResource(new StringAsset(
-                            "quarkus.azure.servicebus.connection-string=Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;"),
+                    .addAsResource(
+                            new StringAsset(
+                                    """
+                                            # supply required configuration for the CDI producer
+                                            quarkus.azure.servicebus.namespace=some.namespace
+                                            # disable the Dev Services to avoid potential configuration issues to interfere with the injection tests
+                                            quarkus.azure.servicebus.devservices.enabled=false
+                                            """),
                             "application.properties"));
 
     @Inject

--- a/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/DeploymentWithSuppressedDevServicesTest.java
+++ b/services/azure-servicebus/deployment/src/test/java/io/quarkiverse/azure/servicebus/deployment/DeploymentWithSuppressedDevServicesTest.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.azure.servicebus.deployment;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * The presence of a connection string (or namespace, not tested here) prevents the Dev Services
+ * from launching the Azure Service Bus emulator and targeting the connection string to it.
+ */
+class DeploymentWithSuppressedDevServicesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(
+                            new StringAsset(
+                                    """
+                                            # We set a connection string. This disables the Dev Services.
+                                            quarkus.azure.servicebus.connection-string=some-connection.string
+
+                                            quarkus.azure.servicebus.devservices.licence-accepted=true
+                                            """),
+                            "application.properties")
+                    .addAsResource("minimal-servicebus-config.json", "servicebus-config.json"));
+
+    @ConfigProperty(name = ServiceBusConfig.CONFIG_KEY_CONNECTION_STRING)
+    String connectionString;
+
+    @Test
+    void connectionStringIsNotChanged() {
+        assertThat(connectionString, is("some-connection.string"));
+    }
+}

--- a/services/azure-servicebus/deployment/src/test/resources/minimal-servicebus-config.json
+++ b/services/azure-servicebus/deployment/src/test/resources/minimal-servicebus-config.json
@@ -1,0 +1,14 @@
+{
+  "UserConfig": {
+    "Namespaces": [
+      {
+        "Name": "sbemulatorns",
+        "Queues": [],
+        "Topics": []
+      }
+    ],
+    "Logging": {
+      "Type": "Console"
+    }
+  }
+}

--- a/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java
+++ b/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.azure.servicebus.runtime;
 
 import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_CONNECTION_STRING;
+import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_ENABLED;
 import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_NAMESPACE;
 
 import jakarta.enterprise.inject.Produces;
@@ -24,9 +25,10 @@ public class ServiceBusClientProducer {
         }
 
         String namespace = config.namespace()
-                .orElseThrow(() -> new ConfigurationException(
-                        "Either the connection string (%s) or the namespace (%s) must be set."
-                                .formatted(CONFIG_KEY_CONNECTION_STRING, CONFIG_KEY_NAMESPACE)));
+                .orElseThrow(() -> new ConfigurationException(String.format(
+                        "Either the connection string (%s) or the namespace (%s) must be set.\n" +
+                                "Alternatively, you can disable the CDI producers of the Azure Service Bus extension with '%s=false'.",
+                        CONFIG_KEY_CONNECTION_STRING, CONFIG_KEY_NAMESPACE, CONFIG_KEY_ENABLED)));
 
         return new ServiceBusClientBuilder()
                 .fullyQualifiedNamespace(namespace + "." + config.domainName())

--- a/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java
+++ b/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.azure.servicebus.runtime;
 
+import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_CONNECTION_STRING;
+import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_NAMESPACE;
+
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
@@ -22,7 +25,8 @@ public class ServiceBusClientProducer {
 
         String namespace = config.namespace()
                 .orElseThrow(() -> new ConfigurationException(
-                        "Either the connection string (quarkus.azure.servicebus.connection-string) or the namespace (quarkus.azure.servicebus.namespace) must be set."));
+                        "Either the connection string (%s) or the namespace (%s) must be set."
+                                .formatted(CONFIG_KEY_CONNECTION_STRING, CONFIG_KEY_NAMESPACE)));
 
         return new ServiceBusClientBuilder()
                 .fullyQualifiedNamespace(namespace + "." + config.domainName())

--- a/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusConfig.java
+++ b/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.azure.servicebus.runtime;
 
+import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.PREFIX;
 import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 
 import java.util.Optional;
@@ -8,9 +9,41 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
-@ConfigMapping(prefix = "quarkus.azure.servicebus")
+@ConfigMapping(prefix = PREFIX)
 @ConfigRoot(phase = RUN_TIME)
 public interface ServiceBusConfig {
+    String PREFIX = "quarkus.azure.servicebus";
+
+    /**
+     * The name of the property to enable or disable the extension.
+     */
+    String CONFIG_KEY_ENABLED = PREFIX + ".enabled";
+
+    /**
+     * The name of the property to configure the connection string.
+     *
+     * @see #connectionString()
+     */
+    String CONFIG_KEY_CONNECTION_STRING = PREFIX + ".connection-string";
+
+    /**
+     * The name of the property to configure the namespace.
+     *
+     * @see #namespace()
+     */
+    String CONFIG_KEY_NAMESPACE = PREFIX + ".namespace";
+
+    /**
+     * The name of the property to configure the domain name.
+     *
+     * @see #domainName()
+     */
+    String CONFIG_KEY_DOMAIN_NAME = PREFIX + ".domain-name";
+
+    /**
+     * The default value of {@link #domainName()}.
+     */
+    String DEFAULT_DOMAIN_NAME = "servicebus.windows.net";
 
     /**
      * Connect to the Service Bus using this connection string.
@@ -22,12 +55,16 @@ public interface ServiceBusConfig {
 
     /**
      * The namespace of the Service Bus.
+     * The domain name is appended to this value to form the fully qualified namespace name.
+     *
+     * @see #domainName()
      */
     Optional<String> namespace();
 
     /**
      * The domain name of the Service Bus.
+     * The domain name is appended to the namespace to form the fully qualified namespace name.
      */
-    @WithDefault("servicebus.windows.net")
+    @WithDefault(DEFAULT_DOMAIN_NAME)
     String domainName();
 }


### PR DESCRIPTION
This is intended as the MVP of new Dev Services for the Azure Service Bus extension.
They manage an Azure Service Bus emulator.

Enhancements for the MVP (feel free to edit the lists):

- [x] fix existing deployment tests
- [x] disable devservice if a Service Bus connection is configured
- [x] require accepting the licence (`quarkus.azure.services.licence-accepted=true`?)
- [x] add deployment tests

Enhancements for follow-up PRs:
- [ ] make the container images configurable
- [ ] make the emulator config file location configurable

@majguo PTAL
