### PR TITLE
Fail early if the CDI producer is insufficiently configured.

### DIFF
--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusProcessor.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusProcessor.java
@@ -3,6 +3,7 @@ package io.quarkiverse.azure.servicebus.deployment;
 import java.util.stream.Stream;
 
 import io.quarkiverse.azure.servicebus.runtime.ServiceBusClientProducer;
+import io.quarkiverse.azure.servicebus.runtime.ServiceBusConfigVerifier;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -22,7 +23,7 @@ public class ServiceBusProcessor {
     @BuildStep
     AdditionalBeanBuildItem producer(ServiceBusBuildTimeConfig config) {
         if (config.enabled()) {
-            return new AdditionalBeanBuildItem(ServiceBusClientProducer.class);
+            return new AdditionalBeanBuildItem(ServiceBusConfigVerifier.class, ServiceBusClientProducer.class);
         }
         return null;
     }

--- a/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java
+++ b/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java
@@ -1,16 +1,10 @@
 package io.quarkiverse.azure.servicebus.runtime;
 
-import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_CONNECTION_STRING;
-import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_ENABLED;
-import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_NAMESPACE;
-
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.messaging.servicebus.ServiceBusClientBuilder;
-
-import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class ServiceBusClientProducer {
 
@@ -24,11 +18,9 @@ public class ServiceBusClientProducer {
                     .connectionString(config.connectionString().get());
         }
 
-        String namespace = config.namespace()
-                .orElseThrow(() -> new ConfigurationException(String.format(
-                        "Either the connection string (%s) or the namespace (%s) must be set.\n" +
-                                "Alternatively, you can disable the CDI producers of the Azure Service Bus extension with '%s=false'.",
-                        CONFIG_KEY_CONNECTION_STRING, CONFIG_KEY_NAMESPACE, CONFIG_KEY_ENABLED)));
+        // Configuration was already verified in ServiceBusConfigVerifier,
+        // so we can rely on the namespace being present here.
+        String namespace = config.namespace().get();
 
         return new ServiceBusClientBuilder()
                 .fullyQualifiedNamespace(namespace + "." + config.domainName())

--- a/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusConfigVerifier.java
+++ b/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusConfigVerifier.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.azure.servicebus.runtime;
+
+import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_CONNECTION_STRING;
+import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_ENABLED;
+import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_NAMESPACE;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.runtime.Startup;
+import io.quarkus.runtime.configuration.ConfigurationException;
+
+/**
+ * Due to lazy initialization of injection points, the CDI producer method of this extension
+ * might be called at application runtime.
+ * <p>
+ * We do not want configuration issues to surface at such a late point in time,
+ * so we verify at application startup that at least one of a connection string or a namespace
+ * is configured.
+ * <p>
+ * This check is only included in the deployment if the extension is enabled.
+ */
+public class ServiceBusConfigVerifier {
+
+    @ConfigProperty(name = CONFIG_KEY_CONNECTION_STRING)
+    Optional<String> connectionString;
+
+    @ConfigProperty(name = CONFIG_KEY_NAMESPACE)
+    Optional<String> namespace;
+
+    @Startup
+    void verifyCdiProducerConfiguration() {
+        if (connectionString.isEmpty() && namespace.isEmpty()) {
+            throw new ConfigurationException(String.format(
+                    "Either the connection string (%s) or the namespace (%s) must be set.\n" +
+                            "Alternatively, you can disable the CDI producers of the Azure Service Bus extension at build time with '%s=false'.",
+                    CONFIG_KEY_CONNECTION_STRING, CONFIG_KEY_NAMESPACE, CONFIG_KEY_ENABLED));
+        }
+    }
+}


### PR DESCRIPTION
Configuration problems that are handled in a CDI producer can cause late deployment errors.
This happens if a produced bean is injected in another bean that is lazily instantiated.

In the context of this Quarkus extension, this means that an application with a REST resource using an injected `ServiceBusClientBuilder` and having neither `quarkus.azure.servicebus.connection-string` nor `quarkus.azure.servicebus.namespace` set, will not fail until the first request to an endpoint provided by the resource is made.

This PR changes this behavior so that the application fails immediately at startup.
It does so by adding a bean with a `@Startup` method that validates the configuration.

## How to Reproduce

See README.md in the attached reproducer application.
[fail-early.zip](https://github.com/user-attachments/files/20835937/fail-early.zip)
