### PR TITLE
The images used by the Azure Service Bus Dev Services can be configured.

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus.adoc
@@ -61,6 +61,10 @@ endif::add-copy-button-to-config-props[]
 --
 The container image name of the Azure Service Bus emulator. See the link:https://mcr.microsoft.com/en-us/artifact/mar/azure-messaging/servicebus-emulator/tags[artifact registry] for available tags of the default image.
 
+The default image uses the `latest` tag. This can lead to build failures if a new incompatible version is published. For stability, it is recommended to specify an explicit version tag.
+
+This extension has been tested and verified working with version `mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2`.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_EMULATOR_IMAGE_NAME+++[]
@@ -70,7 +74,7 @@ Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_EMULATOR_IMAGE_NA
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2`
+|`mcr.microsoft.com/azure-messaging/servicebus-emulator:latest`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-database-image-name]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-database-image-name[`quarkus.azure.servicebus.devservices.database.image-name`]##
 ifdef::add-copy-button-to-config-props[]
@@ -82,6 +86,10 @@ endif::add-copy-button-to-config-props[]
 --
 The container image name of the Microsoft SQL Server required by the Azure Service Bus emulator. See the link:https://mcr.microsoft.com/en-us/artifact/mar/mssql/server/tags[artifact registry] for available tags of the default image.
 
+The default image uses the `latest` tag. This can lead to build failures if a new incompatible version is published. For stability, it is recommended to specify an explicit version tag.
+
+This extension has been tested and verified working with version `mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04`.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_DATABASE_IMAGE_NAME+++[]
@@ -91,7 +99,7 @@ Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_DATABASE_IMAGE_NA
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04`
+|`mcr.microsoft.com/mssql/server:latest`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-enabled[`quarkus.azure.servicebus.enabled`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus.adoc
@@ -38,7 +38,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-To use the Service Bus Dev Services, you must accept the license terms of the Service Bus emulator and the Microsoft SQL Server.
+To use the Azure Service Bus Dev Services, you must accept the license terms of the Service Bus emulator and the Microsoft SQL Server.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -50,6 +50,48 @@ endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`false`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-emulator-image-name]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-emulator-image-name[`quarkus.azure.servicebus.devservices.emulator.image-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.devservices.emulator.image-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The container image name of the Azure Service Bus emulator. See the link:https://mcr.microsoft.com/en-us/artifact/mar/azure-messaging/servicebus-emulator/tags[artifact registry] for available tags of the default image.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_EMULATOR_IMAGE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_EMULATOR_IMAGE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-database-image-name]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-database-image-name[`quarkus.azure.servicebus.devservices.database.image-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.devservices.database.image-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The container image name of the Microsoft SQL Server required by the Azure Service Bus emulator. See the link:https://mcr.microsoft.com/en-us/artifact/mar/mssql/server/tags[artifact registry] for available tags of the default image.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_DATABASE_IMAGE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_DATABASE_IMAGE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-enabled[`quarkus.azure.servicebus.enabled`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus_quarkus.azure.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus_quarkus.azure.adoc
@@ -61,6 +61,10 @@ endif::add-copy-button-to-config-props[]
 --
 The container image name of the Azure Service Bus emulator. See the link:https://mcr.microsoft.com/en-us/artifact/mar/azure-messaging/servicebus-emulator/tags[artifact registry] for available tags of the default image.
 
+The default image uses the `latest` tag. This can lead to build failures if a new incompatible version is published. For stability, it is recommended to specify an explicit version tag.
+
+This extension has been tested and verified working with version `mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2`.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_EMULATOR_IMAGE_NAME+++[]
@@ -70,7 +74,7 @@ Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_EMULATOR_IMAGE_NA
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2`
+|`mcr.microsoft.com/azure-messaging/servicebus-emulator:latest`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-database-image-name]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-database-image-name[`quarkus.azure.servicebus.devservices.database.image-name`]##
 ifdef::add-copy-button-to-config-props[]
@@ -82,6 +86,10 @@ endif::add-copy-button-to-config-props[]
 --
 The container image name of the Microsoft SQL Server required by the Azure Service Bus emulator. See the link:https://mcr.microsoft.com/en-us/artifact/mar/mssql/server/tags[artifact registry] for available tags of the default image.
 
+The default image uses the `latest` tag. This can lead to build failures if a new incompatible version is published. For stability, it is recommended to specify an explicit version tag.
+
+This extension has been tested and verified working with version `mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04`.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_DATABASE_IMAGE_NAME+++[]
@@ -91,7 +99,7 @@ Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_DATABASE_IMAGE_NA
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04`
+|`mcr.microsoft.com/mssql/server:latest`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-enabled[`quarkus.azure.servicebus.enabled`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus_quarkus.azure.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-servicebus_quarkus.azure.adoc
@@ -38,7 +38,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-To use the Service Bus Dev Services, you must accept the license terms of the Service Bus emulator and the Microsoft SQL Server.
+To use the Azure Service Bus Dev Services, you must accept the license terms of the Service Bus emulator and the Microsoft SQL Server.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -50,6 +50,48 @@ endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`false`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-emulator-image-name]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-emulator-image-name[`quarkus.azure.servicebus.devservices.emulator.image-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.devservices.emulator.image-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The container image name of the Azure Service Bus emulator. See the link:https://mcr.microsoft.com/en-us/artifact/mar/azure-messaging/servicebus-emulator/tags[artifact registry] for available tags of the default image.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_EMULATOR_IMAGE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_EMULATOR_IMAGE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-database-image-name]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-devservices-database-image-name[`quarkus.azure.servicebus.devservices.database.image-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.servicebus.devservices.database.image-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The container image name of the Microsoft SQL Server required by the Azure Service Bus emulator. See the link:https://mcr.microsoft.com/en-us/artifact/mar/mssql/server/tags[artifact registry] for available tags of the default image.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_DATABASE_IMAGE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_SERVICEBUS_DEVSERVICES_DATABASE_IMAGE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-azure-servicebus_quarkus-azure-servicebus-enabled]] [.property-path]##link:#quarkus-azure-servicebus_quarkus-azure-servicebus-enabled[`quarkus.azure.servicebus.enabled`]##
 ifdef::add-copy-button-to-config-props[]

--- a/services/azure-servicebus/deployment/pom.xml
+++ b/services/azure-servicebus/deployment/pom.xml
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <!-- required by the underlying Testcontainers library for checking readiness
-             of the MSSQL database container used by the Azure Service Bus emulator -->
+             of the Microsoft SQL Server container used by the Azure Service Bus emulator -->
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
         </dependency>

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesConfig.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesConfig.java
@@ -36,11 +36,21 @@ public interface ServiceBusDevServicesConfig {
     boolean enabled();
 
     /**
-     * To use the Service Bus Dev Services, you must accept the license terms of the Service Bus emulator and the Microsoft SQL
-     * Server.
+     * To use the Azure Service Bus Dev Services, you must accept the license terms
+     * of the Service Bus emulator and the Microsoft SQL Server.
      */
     @WithDefault("false")
     boolean licenseAccepted();
+
+    /**
+     * Configuration of the Azure Service Bus emulator.
+     */
+    ServiceBusDevServicesEmulatorConfig emulator();
+
+    /**
+     * Configuration of the Microsoft SQL Server required by the Azure Service Bus emulator.
+     */
+    ServiceBusDevServicesDatabaseConfig database();
 
     class Enabled implements BooleanSupplier {
         final ServiceBusDevServicesConfig config;

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesDatabaseConfig.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesDatabaseConfig.java
@@ -3,7 +3,7 @@ package io.quarkiverse.azure.servicebus.deployment;
 import io.smallrye.config.WithDefault;
 
 public interface ServiceBusDevServicesDatabaseConfig {
-    String DEFAULT_IMAGE_NAME = "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04";
+    String DEFAULT_IMAGE_NAME = "mcr.microsoft.com/mssql/server:latest";
 
     String PREFIX = ServiceBusDevServicesConfig.PREFIX + ".database";
     /**
@@ -16,6 +16,13 @@ public interface ServiceBusDevServicesDatabaseConfig {
      * The container image name of the Microsoft SQL Server required by the Azure Service Bus emulator.
      * See the <a href="https://mcr.microsoft.com/en-us/artifact/mar/mssql/server/tags">artifact
      * registry</a> for available tags of the default image.
+     * <p>
+     * The default image uses the {@code latest} tag.
+     * This can lead to build failures if a new incompatible version is published.
+     * For stability, it is recommended to specify an explicit version tag.
+     * <p>
+     * This extension has been tested and verified working with version
+     * {@code mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04}.
      */
     @WithDefault(DEFAULT_IMAGE_NAME)
     String imageName();

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesDatabaseConfig.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesDatabaseConfig.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.azure.servicebus.deployment;
+
+import io.smallrye.config.WithDefault;
+
+public interface ServiceBusDevServicesDatabaseConfig {
+    String DEFAULT_IMAGE_NAME = "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04";
+
+    String PREFIX = ServiceBusDevServicesConfig.PREFIX + ".database";
+    /**
+     * The name of the property to configure the container image name of the
+     * Microsoft SQL Server required by the Azure Service Bus emulator.
+     */
+    String CONFIG_KEY_IMAGE_NAME = PREFIX + ".image-name";
+
+    /**
+     * The container image name of the Microsoft SQL Server required by the Azure Service Bus emulator.
+     * See the <a href="https://mcr.microsoft.com/en-us/artifact/mar/mssql/server/tags">artifact
+     * registry</a> for available tags of the default image.
+     */
+    @WithDefault(DEFAULT_IMAGE_NAME)
+    String imageName();
+}

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesEmulatorConfig.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesEmulatorConfig.java
@@ -3,7 +3,7 @@ package io.quarkiverse.azure.servicebus.deployment;
 import io.smallrye.config.WithDefault;
 
 public interface ServiceBusDevServicesEmulatorConfig {
-    String DEFAULT_IMAGE_NAME = "mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2";
+    String DEFAULT_IMAGE_NAME = "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest";
 
     String PREFIX = ServiceBusDevServicesConfig.PREFIX + ".emulator";
     /**
@@ -16,6 +16,13 @@ public interface ServiceBusDevServicesEmulatorConfig {
      * The container image name of the Azure Service Bus emulator.
      * See the <a href="https://mcr.microsoft.com/en-us/artifact/mar/azure-messaging/servicebus-emulator/tags">artifact
      * registry</a> for available tags of the default image.
+     * <p>
+     * The default image uses the {@code latest} tag.
+     * This can lead to build failures if a new incompatible version is published.
+     * For stability, it is recommended to specify an explicit version tag.
+     * <p>
+     * This extension has been tested and verified working with version
+     * {@code mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2}.
      */
     @WithDefault(DEFAULT_IMAGE_NAME)
     String imageName();

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesEmulatorConfig.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesEmulatorConfig.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.azure.servicebus.deployment;
+
+import io.smallrye.config.WithDefault;
+
+public interface ServiceBusDevServicesEmulatorConfig {
+    String DEFAULT_IMAGE_NAME = "mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2";
+
+    String PREFIX = ServiceBusDevServicesConfig.PREFIX + ".emulator";
+    /**
+     * The name of the property to configure the container image name of the
+     * Azure Service Bus emulator.
+     */
+    String CONFIG_KEY_IMAGE_NAME = PREFIX + ".image-name";
+
+    /**
+     * The container image name of the Azure Service Bus emulator.
+     * See the <a href="https://mcr.microsoft.com/en-us/artifact/mar/azure-messaging/servicebus-emulator/tags">artifact
+     * registry</a> for available tags of the default image.
+     */
+    @WithDefault(DEFAULT_IMAGE_NAME)
+    String imageName();
+}

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesProcessor.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesProcessor.java
@@ -3,6 +3,8 @@ package io.quarkiverse.azure.servicebus.deployment;
 import static io.quarkiverse.azure.servicebus.deployment.ServiceBusDevServicesConfig.CONFIG_KEY_DEVSERVICE_ENABLED;
 import static io.quarkiverse.azure.servicebus.deployment.ServiceBusDevServicesConfig.CONFIG_KEY_LICENSE_ACCEPTED;
 import static io.quarkiverse.azure.servicebus.deployment.ServiceBusProcessor.FEATURE;
+import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_CONNECTION_STRING;
+import static io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig.CONFIG_KEY_NAMESPACE;
 
 import java.net.URL;
 import java.util.Collections;
@@ -14,7 +16,6 @@ import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.MountableFile;
 
-import io.quarkiverse.azure.servicebus.runtime.ServiceBusConfig;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -50,8 +51,7 @@ public class ServiceBusDevServicesProcessor {
     }
 
     private static boolean isServiceBusConnectionConfigured() {
-        return ConfigUtils.isPropertyPresent(ServiceBusConfig.CONFIG_KEY_NAMESPACE)
-                || ConfigUtils.isPropertyPresent(ServiceBusConfig.CONFIG_KEY_CONNECTION_STRING);
+        return ConfigUtils.isAnyPropertyPresent(List.of(CONFIG_KEY_NAMESPACE, CONFIG_KEY_CONNECTION_STRING));
     }
 
     private static boolean hasConfigurationProblems(ServiceBusDevServicesConfig devServicesConfig,
@@ -95,7 +95,7 @@ public class ServiceBusDevServicesProcessor {
 
         emulator.start();
 
-        Map<String, String> configOverrides = Map.of(ServiceBusConfig.CONFIG_KEY_CONNECTION_STRING,
+        Map<String, String> configOverrides = Map.of(CONFIG_KEY_CONNECTION_STRING,
                 emulator.getConnectionString());
 
         RunningDevService databaseDevService = new RunningDevService(FEATURE, database.getContainerId(), database::close,


### PR DESCRIPTION
The container images for the Azure Service Bus emulator and the MSSQL Server can now be configured.

The default images use the `latest` image tag instead of a specific version.
This means that users using the default configuration always get the most current version of the emulator. This might break tests if there are incompatible changes in newer emulator versions. Therefore the docs recommend to use specific image versions and include a recommended version.