### PR TITLE
Improve early detection of missing connection configuration

### DIFF
--- a/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java
+++ b/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java
@@ -18,9 +18,8 @@ public class ServiceBusClientProducer {
                     .connectionString(config.connectionString().get());
         }
 
-        // Configuration was already verified in ServiceBusConfigVerifier,
-        // so we can rely on the namespace being present here.
-        String namespace = config.namespace().get();
+        String namespace = config.namespace()
+                .orElseThrow(ServiceBusConfigVerifier::missingConnectionConfigurationException);
 
         return new ServiceBusClientBuilder()
                 .fullyQualifiedNamespace(namespace + "." + config.domainName())


### PR DESCRIPTION
Moving detection of missing connection config parameters to a method annotated with `@Startup` was not sufficient.
The `ServiceBusClientBuilder` might be used in another method also annotated with `@Startup`. This gives a race condition where in roughly 50% of the application launches `get()` is called on en empty `Optional` [here](https://github.com/quarkiverse/quarkus-azure-services/blob/ab2eed699388299818603d593ca90c184e140f8d/services/azure-servicebus/runtime/src/main/java/io/quarkiverse/azure/servicebus/runtime/ServiceBusClientProducer.java#L23-L23).
```text
Failed to start application: java.lang.RuntimeException: Failed to start quarkus
Caused by: java.lang.RuntimeException: Error injecting com.azure.messaging.servicebus.ServiceBusClientBuilder de.hs.demo.azure.ServiceBusSubscriber.serviceBusClientBuilder
Caused by: java.util.NoSuchElementException: No value present
```

This is fixed by adding a priority to `ServiceBusConfigVerifier.verifyCdiProducerConfiguration()` that ensures the method is triggered earlier.
This guards against code that just uses `@Startup` but does not cover cases where code is executed with low priorites like `Startup(0)`.
To be really sure, I re-introduced late verification in the producer method.