### PR TITLE
Fix QuarkusIntegrationTests for containers

### DIFF
--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesProcessor.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesProcessor.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.jboss.logging.Logger;
 import org.testcontainers.azure.ServiceBusEmulatorContainer;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.Network;
@@ -28,6 +29,7 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class ServiceBusDevServicesProcessor {
 
+    private static final Logger log = Logger.getLogger(ServiceBusDevServicesProcessor.class);
     private static final String EMULATOR_CONFIG_FILE = "servicebus-config.json";
     public static final String SERVICEBUS_EULA_URL = "https://github.com/Azure/azure-service-bus-emulator-installer/blob/main/EMULATOR_EULA.txt";
     public static final String MSSQL_SERVER_EULA_URL = "https://hub.docker.com/r/microsoft/mssql-server";
@@ -80,6 +82,8 @@ public class ServiceBusDevServicesProcessor {
     }
 
     private List<RunningDevService> startContainers(ServiceBusDevServicesConfig devServicesConfig) {
+        log.info("Dev Services for Azure Service Bus starting the Azure Service Bus emulator");
+
         Network internalNetwork = Network.newNetwork();
 
         MSSQLServerContainer<?> database = new MSSQLServerContainer<>(devServicesConfig.database().imageName())
@@ -93,6 +97,7 @@ public class ServiceBusDevServicesProcessor {
                 .withNetwork(internalNetwork);
 
         emulator.start();
+        log.infof("Azure Service Bus emulator started - connection string is '%s'", emulator.getConnectionString());
 
         Map<String, String> configOverrides = Map.of(CONFIG_KEY_CONNECTION_STRING,
                 emulator.getConnectionString());

--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesProcessor.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesProcessor.java
@@ -23,6 +23,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -30,6 +31,7 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 public class ServiceBusDevServicesProcessor {
 
     private static final Logger log = Logger.getLogger(ServiceBusDevServicesProcessor.class);
+    private static final int DEFAULT_EMULATOR_PORT = 5672;
     private static final String EMULATOR_CONFIG_FILE = "servicebus-config.json";
     public static final String SERVICEBUS_EULA_URL = "https://github.com/Azure/azure-service-bus-emulator-installer/blob/main/EMULATOR_EULA.txt";
     public static final String MSSQL_SERVER_EULA_URL = "https://hub.docker.com/r/microsoft/mssql-server";
@@ -38,13 +40,14 @@ public class ServiceBusDevServicesProcessor {
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { DevServicesConfig.Enabled.class,
             ServiceBusDevServicesConfig.Enabled.class })
     public List<DevServicesResultBuildItem> startServiceBusEmulator(ServiceBusDevServicesConfig devServicesConfig,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             BuildProducer<ValidationErrorBuildItem> configErrors) {
         if (isServiceBusConnectionConfigured() || hasConfigurationProblems(devServicesConfig, configErrors)) {
             return null;
         }
 
         if (devServices == null) {
-            devServices = startContainers(devServicesConfig);
+            devServices = startContainers(devServicesConfig, devServicesSharedNetworkBuildItem);
         }
 
         return devServices.stream()
@@ -81,26 +84,38 @@ public class ServiceBusDevServicesProcessor {
         return resourceUrl == null;
     }
 
-    private List<RunningDevService> startContainers(ServiceBusDevServicesConfig devServicesConfig) {
+    private List<RunningDevService> startContainers(ServiceBusDevServicesConfig devServicesConfig,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
         log.info("Dev Services for Azure Service Bus starting the Azure Service Bus emulator");
 
-        Network internalNetwork = Network.newNetwork();
+        boolean useSharedNetwork = !devServicesSharedNetworkBuildItem.isEmpty();
 
         MSSQLServerContainer<?> database = new MSSQLServerContainer<>(devServicesConfig.database().imageName())
                 .acceptLicense()
-                .withNetwork(internalNetwork);
+                .withNetwork(Network.SHARED);
 
-        ServiceBusEmulatorContainer emulator = new ServiceBusEmulatorContainer(devServicesConfig.emulator().imageName())
+        ServiceBusEmulatorContainer emulator = new ServiceBusEmulatorContainer(
+                devServicesConfig.emulator().imageName()) {
+            @Override
+            public String getHost() {
+                return useSharedNetwork ? getNetworkAliases().get(0) : super.getHost();
+            }
+
+            @Override
+            public Integer getMappedPort(int originalPort) {
+                return useSharedNetwork ? DEFAULT_EMULATOR_PORT : super.getMappedPort(originalPort);
+            }
+        }
                 .acceptLicense()
                 .withConfig(MountableFile.forClasspathResource(EMULATOR_CONFIG_FILE))
                 .withMsSqlServerContainer(database)
-                .withNetwork(internalNetwork);
+                .withNetwork(Network.SHARED);
 
         emulator.start();
         log.infof("Azure Service Bus emulator started - connection string is '%s'", emulator.getConnectionString());
 
-        Map<String, String> configOverrides = Map.of(CONFIG_KEY_CONNECTION_STRING,
-                emulator.getConnectionString());
+        Map<String, String> configOverrides = Map.of(
+                CONFIG_KEY_CONNECTION_STRING, emulator.getConnectionString());
 
         RunningDevService databaseDevService = new RunningDevService(FEATURE, database.getContainerId(), database::close,
                 Collections.emptyMap());


### PR DESCRIPTION
`@QuarkusIntegrationTest` did not work when the build product was a container.

`mvn verify -DskipITs=false` worked, but `mvn verify -DskipITs=false -Dquarkus.container-image.build` failed befause the Service Bus emulator container would always produce a connection string meant to be used from the test host.
To be reachable from the application container under test, the connection string has to be adjusted to use the hostname of the emulator in the shared network and the unmapped port.
See also the [Launching Containers](https://quarkus.io/guides/getting-started-testing#launching-containers) section of the _Testing Your Application_ guide.