### PR TITLE
Fix log message

### DIFF
--- a/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesProcessor.java
+++ b/services/azure-servicebus/deployment/src/main/java/io/quarkiverse/azure/servicebus/deployment/ServiceBusDevServicesProcessor.java
@@ -105,7 +105,7 @@ public class ServiceBusDevServicesProcessor {
         log.info("Dev Services for Azure Service Bus starting the Azure Service Bus emulator");
 
         boolean useSharedNetwork = !devServicesSharedNetworkBuildItem.isEmpty();
-        log.debug(useSharedNetwork ? "Using" : "Not using" + " a shared network");
+        log.debug((useSharedNetwork ? "Using" : "Not using") + " a shared network");
 
         MountableFile configFile = configFile(devServicesConfig.emulator());
         log.debugf("Azure Service Bus emulator uses configuration file at '%s'", configFile.getResolvedPath());


### PR DESCRIPTION
Due to missing brackets, the message would be "Using" instead of "Using a shared network" when a shared network was used.