### PR TITLE
Support more than five labels for app configuration.

### DIFF
--- a/.github/create-azure-resources.sh
+++ b/.github/create-azure-resources.sh
@@ -48,6 +48,15 @@ az appconfig kv set \
     --label prod \
     --yes
 
+for i in {1..7}; do
+    az appconfig kv set \
+        --name "${APP_CONFIG_NAME}" \
+        --key "another.prop.l${i}" \
+        --value "Label ${i}" \
+        --label "l${i}" \
+        --yes
+done
+
 # Azure Key Vault Extension
 # The same commands used in 
 #  - integration-tests/README.md

--- a/integration-tests/azure-app-configuration/README.md
+++ b/integration-tests/azure-app-configuration/README.md
@@ -87,6 +87,15 @@ az appconfig kv set \
     --label prod \
     --yes
     
+for i in {1..7}; do
+    az appconfig kv set \
+        --name "${APP_CONFIG_NAME}" \
+        --key "another.prop.l${i}" \
+        --value "Label ${i}" \
+        --label "l${i}" \
+        --yes
+done
+
 export QUARKUS_AZURE_APP_CONFIGURATION_ENDPOINT=$(az appconfig show \
   --resource-group "${RESOURCE_GROUP_NAME}" \
   --name "${APP_CONFIG_NAME}" \

--- a/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationResource.java
+++ b/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationResource.java
@@ -66,9 +66,13 @@ public class AzureAppConfigurationResource implements QuarkusTestResourceLifecyc
     private static URL getResource(HttpExchange exchange) {
         Map<String, String> params = getQueryParameters(exchange.getRequestURI().getQuery());
         URL resource;
-
+        String labels = params.get("label");
         if (Objects.equals("prod", params.get("label"))) {
             resource = loadResource("response_prod.json");
+        } else if (Objects.equals("l1,l2,l3,l4,l5", labels)) {
+            resource = loadResource("response_labels_1.json");
+        } else if (Objects.equals("l6,l7", labels)) {
+            resource = loadResource("response_labels_2.json");
         } else {
             resource = loadResource("response.json");
         }

--- a/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationWithSevenLabelsTest.java
+++ b/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/AzureAppConfigurationWithSevenLabelsTest.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.azure.app.configuration.it;
+
+import static io.restassured.RestAssured.given;
+import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
+import static jakarta.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@WithTestResource(AzureAppConfigurationResource.class)
+@TestProfile(SevenLabelsConfigurationProfile.class)
+class AzureAppConfigurationWithSevenLabelsTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 4, 5, 6, 7 })
+    void testAppConfigurationSupportsMoreThanFiveLabels(int labelNumber) {
+        given()
+                .get("/config/{name}", "another.prop.l" + labelNumber)
+                .then()
+                .statusCode(OK.getStatusCode())
+                .body(equalTo("Label " + labelNumber));
+    }
+
+    @Test
+    void configWithoutLabelIsNotProvided() {
+        given()
+                .get("/config/{name}", "my.prop")
+                .then()
+                .statusCode(NO_CONTENT.getStatusCode());
+    }
+}

--- a/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/SevenLabelsConfigurationProfile.java
+++ b/integration-tests/azure-app-configuration/src/test/java/io/quarkiverse/azure/app/configuration/it/SevenLabelsConfigurationProfile.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.azure.app.configuration.it;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class SevenLabelsConfigurationProfile implements QuarkusTestProfile {
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.azure.app.configuration.labels", "l1,l2,l3,l4,l5,l6,l7");
+    }
+}

--- a/integration-tests/azure-app-configuration/src/test/resources/response_labels_1.json
+++ b/integration-tests/azure-app-configuration/src/test/resources/response_labels_1.json
@@ -1,0 +1,54 @@
+{
+  "items": [
+    {
+      "etag": "l1hQuZysAyuOXArQpGaZAYxV_7nNctKmKYANd_IUoIw",
+      "key": "another.prop.l1",
+      "label": "l1",
+      "content_type": "",
+      "value": "Label 1",
+      "tags": {},
+      "locked": false,
+      "last_modified": "2022-11-29T17:07:33+00:00"
+    },
+    {
+      "etag": "l1hQuZysAyuOXArQpGaZAYxV_7nNctKmKYANd_IUoIw",
+      "key": "another.prop.l2",
+      "label": "l2",
+      "content_type": "",
+      "value": "Label 2",
+      "tags": {},
+      "locked": false,
+      "last_modified": "2022-11-29T17:07:33+00:00"
+    },
+    {
+      "etag": "l1hQuZysAyuOXArQpGaZAYxV_7nNctKmKYANd_IUoIw",
+      "key": "another.prop.l3",
+      "label": "l3",
+      "content_type": "",
+      "value": "Label 3",
+      "tags": {},
+      "locked": false,
+      "last_modified": "2022-11-29T17:07:33+00:00"
+    },
+    {
+      "etag": "l1hQuZysAyuOXArQpGaZAYxV_7nNctKmKYANd_IUoIw",
+      "key": "another.prop.l4",
+      "label": "l4",
+      "content_type": "",
+      "value": "Label 4",
+      "tags": {},
+      "locked": false,
+      "last_modified": "2022-11-29T17:07:33+00:00"
+    },
+    {
+      "etag": "l1hQuZysAyuOXArQpGaZAYxV_7nNctKmKYANd_IUoIw",
+      "key": "another.prop.l5",
+      "label": "l5",
+      "content_type": "",
+      "value": "Label 5",
+      "tags": {},
+      "locked": false,
+      "last_modified": "2022-11-29T17:07:33+00:00"
+    }
+  ]
+}

--- a/integration-tests/azure-app-configuration/src/test/resources/response_labels_2.json
+++ b/integration-tests/azure-app-configuration/src/test/resources/response_labels_2.json
@@ -1,0 +1,24 @@
+{
+  "items": [
+    {
+      "etag": "l1hQuZysAyuOXArQpGaZAYxV_7nNctKmKYANd_IUoIw",
+      "key": "another.prop.l6",
+      "label": "l6",
+      "content_type": "",
+      "value": "Label 6",
+      "tags": {},
+      "locked": false,
+      "last_modified": "2022-11-29T17:07:33+00:00"
+    },
+    {
+      "etag": "l1hQuZysAyuOXArQpGaZAYxV_7nNctKmKYANd_IUoIw",
+      "key": "another.prop.l7",
+      "label": "l7",
+      "content_type": "",
+      "value": "Label 7",
+      "tags": {},
+      "locked": false,
+      "last_modified": "2022-11-29T17:07:33+00:00"
+    }
+  ]
+}


### PR DESCRIPTION
Azure App Configuration supports getting configuration with a maximum of five labels. 
Attempting to fetch fore more results in 
> com.azure.core.exception.HttpResponseException: Status code 400, "{"type":"https://azconfig.io/errors/invalid-argument","title":"Invalid request parameter 'label'","name":"label","detail":"label(0): Too many values. Maximum supported is 5","pos":0,"status":400}"

This pull request adds batching, so that config is fetched from App Configuration in several requests if the number of labels is larger than five.