### PR TITLE
Fix link to allcontributors emoji key page

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Contributions are always welcome, but better create an issue to discuss them pri
 
 ## Contributors ✨
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/emoji-key/)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
The old link gives a _404_, updated.