### PR TITLE
Release 1.2.2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "1.2.1"
+  current-version: "1.2.2"
   next-version: "999-SNAPSHOT"
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following matrix shows the compatibility of the extensions with Quarkus vers
 
 | Quarkus Azure services Version | Quarkus Version | Java Version |
 |--------------------------------|------------------|-----------------|
+| [1.2.2](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.2/pom.xml#L12) | [3.31.1](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.2/pom.xml#L20) | [Java 17](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.2/pom.xml#L17-L18) |
 | [1.2.1](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.1/pom.xml#L12) | [3.28.4](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.1/pom.xml#L20) | [Java 17](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.1/pom.xml#L17-L18) |
 | [1.2.0](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.0/pom.xml#L12) | [3.26.3](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.0/pom.xml#L20) | [Java 17](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.0/pom.xml#L17-L18) |
 | [1.1.9](https://github.com/quarkiverse/quarkus-azure-services/blob/1.1.9/pom.xml#L12) | [3.25.3](https://github.com/quarkiverse/quarkus-azure-services/blob/1.1.9/pom.xml#L20) | [Java 17](https://github.com/quarkiverse/quarkus-azure-services/blob/1.1.9/pom.xml#L17-L18) |

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:project-version: 1.2.1
+:project-version: 1.2.2
 
 :examples-dir: ./../examples/

--- a/integration-tests/azure-app-configuration/README.md
+++ b/integration-tests/azure-app-configuration/README.md
@@ -33,7 +33,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.1`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -41,7 +41,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-cosmos/README.md
+++ b/integration-tests/azure-cosmos/README.md
@@ -33,7 +33,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.1`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -41,7 +41,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-eventhubs/README.md
+++ b/integration-tests/azure-eventhubs/README.md
@@ -33,7 +33,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.1`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -41,7 +41,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-keyvault/README.md
+++ b/integration-tests/azure-keyvault/README.md
@@ -32,7 +32,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.1`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -40,7 +40,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-servicebus-devservices/README.md
+++ b/integration-tests/azure-servicebus-devservices/README.md
@@ -32,7 +32,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
-First, you need to find out the latest release version of the Quarkus Azure services extensions from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.1`.
+First, you need to find out the latest release version of the Quarkus Azure services extensions from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -40,7 +40,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-servicebus/README.md
+++ b/integration-tests/azure-servicebus/README.md
@@ -30,7 +30,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
-First, you need to find out the latest release version of the Quarkus Azure services extensions from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.1`.
+First, you need to find out the latest release version of the Quarkus Azure services extensions from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -38,7 +38,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-services-together/README.md
+++ b/integration-tests/azure-services-together/README.md
@@ -34,7 +34,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.1`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -42,7 +42,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-storage-blob/README.md
+++ b/integration-tests/azure-storage-blob/README.md
@@ -33,7 +33,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.1`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -41,7 +41,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <relativePath></relativePath>
 </parent>
 ```


### PR DESCRIPTION
This pull request updates the project version from 1.2.1 to 1.2.2 throughout the codebase and documentation. The changes ensure consistency in version references for users and developers, and update compatibility information for the new release.

Version update across the project:

* Bumped the project version from `1.2.1` to `1.2.2` in the main configuration file `.github/project.yml` and the documentation attributes (`docs/modules/ROOT/pages/includes/attributes.adoc`). [[1]](diffhunk://#diff-735957720c86e5ec3ee129d26dde30a1fd6b7e485100843ef9b576269eb065e9L2-R2) [[2]](diffhunk://#diff-6a9cf7ce7ec74bc87cf4d9b920b636a61915b0ad2683689d9ee8280a1debbf37L1-R1)

Documentation and compatibility updates:

* Updated all relevant `README.md` files in integration test modules to reference version `1.2.2` instead of `1.2.1`, including instructions and example `pom.xml` snippets. [[1]](diffhunk://#diff-e0cabaff689084ec2c6cc8b0b114c5e905b74e2825b9539493819e9778551596L36-R44) [[2]](diffhunk://#diff-7f0db9603140f883c5de68e67df9353840d861cb1b02737ad9a87964c91166faL36-R44) [[3]](diffhunk://#diff-3c96460779d46e68252dbae437e34f43a30bcee936601f2548412245d41596bdL36-R44) [[4]](diffhunk://#diff-72ce6bea53acc1282599f72ccd4785fc62cefc306f860fcd46248d995fe0e9b4L35-R43) [[5]](diffhunk://#diff-18fdedaa25337240320cb72bd84ffa5f7ab80544149e988371aea713bd152e2cL35-R43) [[6]](diffhunk://#diff-c50ebbfe5f5a5efa3bb96d119e51576ff2383146f02e05e4889e299aef94096eL33-R41) [[7]](diffhunk://#diff-17cf8bf682dbcb2192299e52b574c545dabcc1e51dff268ad1fad2f4af6db6a3L37-R45) [[8]](diffhunk://#diff-1f65cacb57529181d1ffbba2c9967090d34496198ed837f2ed389448bedd3b2bL36-R44)
* Added the new version `1.2.2` with its corresponding Quarkus and Java compatibility information to the main compatibility matrix in the root `README.md`.