### PR TITLE
fix: (Line: 36, Col: 1): 'concurrency' is already defined, (Line: 40, Col: 1): 'defaults' is already defined

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -25,14 +25,6 @@ env:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-defaults:
-  run:
-    shell: bash
-
 jobs:
   build:
     permissions:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration by removing the `concurrency` and `defaults` sections from the `.github/workflows/quarkus-snapshot.yaml` file. This simplifies the workflow setup.