### PR TITLE
feat: add property to skip-api-version-check

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-azure-storage-blob.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-storage-blob.adoc
@@ -143,6 +143,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++default-storage-blob+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-storage-blob_quarkus-azure-storage-blob-devservices-skip-api-version-check]] [.property-path]##link:#quarkus-azure-storage-blob_quarkus-azure-storage-blob-devservices-skip-api-version-check[`quarkus.azure.storage.blob.devservices.skip-api-version-check`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.storage.blob.devservices.skip-api-version-check+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+By default, Azurite will check the request API version is valid API version. If this property is set to true, the API version check will be skipped, and the request with any API version will be accepted.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_STORAGE_BLOB_DEVSERVICES_SKIP_API_VERSION_CHECK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_STORAGE_BLOB_DEVSERVICES_SKIP_API_VERSION_CHECK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a| [[quarkus-azure-storage-blob_quarkus-azure-storage-blob-enabled]] [.property-path]##link:#quarkus-azure-storage-blob_quarkus-azure-storage-blob-enabled[`quarkus.azure.storage.blob.enabled`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.azure.storage.blob.enabled+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-azure-storage-blob_quarkus.azure.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-azure-storage-blob_quarkus.azure.adoc
@@ -143,6 +143,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++default-storage-blob+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-azure-storage-blob_quarkus-azure-storage-blob-devservices-skip-api-version-check]] [.property-path]##link:#quarkus-azure-storage-blob_quarkus-azure-storage-blob-devservices-skip-api-version-check[`quarkus.azure.storage.blob.devservices.skip-api-version-check`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.azure.storage.blob.devservices.skip-api-version-check+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+By default, Azurite will check the request API version is valid API version. If this property is set to true, the API version check will be skipped, and the request with any API version will be accepted.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AZURE_STORAGE_BLOB_DEVSERVICES_SKIP_API_VERSION_CHECK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AZURE_STORAGE_BLOB_DEVSERVICES_SKIP_API_VERSION_CHECK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a| [[quarkus-azure-storage-blob_quarkus-azure-storage-blob-enabled]] [.property-path]##link:#quarkus-azure-storage-blob_quarkus-azure-storage-blob-enabled[`quarkus.azure.storage.blob.enabled`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.azure.storage.blob.enabled+++[]

--- a/services/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/DevServicesStorageBlobProcessor.java
+++ b/services/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/DevServicesStorageBlobProcessor.java
@@ -156,7 +156,8 @@ public class DevServicesStorageBlobProcessor {
         Supplier<RunningDevService> storageBlobServerSupplier = () -> {
             QuarkusPortAzuriteContainer azuriteContainer = new QuarkusPortAzuriteContainer(dockerImageName,
                     storageBlobDevServicesConfig.port(),
-                    launchMode == DEVELOPMENT ? storageBlobDevServicesConfig.serviceName() : null, useSharedNetwork);
+                    launchMode == DEVELOPMENT ? storageBlobDevServicesConfig.serviceName() : null, useSharedNetwork,
+                    storageBlobDevServicesConfig.skipApiVersionCheck());
             timeout.ifPresent(azuriteContainer::withStartupTimeout);
             azuriteContainer.start();
             return new RunningDevService(StorageBlobProcessor.FEATURE, azuriteContainer.getContainerId(),
@@ -177,14 +178,16 @@ public class DevServicesStorageBlobProcessor {
     private static class QuarkusPortAzuriteContainer extends GenericContainer<QuarkusPortAzuriteContainer> {
         private final OptionalInt fixedExposedPort;
         private final boolean useSharedNetwork;
+        private final boolean skipApiVersionCheck;
 
         private String hostName = null;
 
         public QuarkusPortAzuriteContainer(DockerImageName dockerImageName, OptionalInt fixedExposedPort, String serviceName,
-                boolean useSharedNetwork) {
+                boolean useSharedNetwork, boolean skipApiVersionCheck) {
             super(dockerImageName);
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
+            this.skipApiVersionCheck = skipApiVersionCheck;
 
             if (serviceName != null) {
                 withLabel(DEV_SERVICE_LABEL, serviceName);
@@ -204,6 +207,10 @@ public class DevServicesStorageBlobProcessor {
                 addFixedExposedPort(fixedExposedPort.getAsInt(), EXPOSED_PORT);
             } else {
                 addExposedPort(EXPOSED_PORT);
+            }
+            if (skipApiVersionCheck) {
+                setCommand("azurite", "-l", "/data", "blobHost", "0.0.0.0", "queueHost", "0.0.0.0", "--tableHost", "0.0.0.0",
+                        "--skipApiVersionCheck");
             }
         }
 

--- a/services/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/StorageBlobDevServicesConfig.java
+++ b/services/azure-storage-blob/deployment/src/main/java/io/quarkiverse/azure/storage/blob/deployment/StorageBlobDevServicesConfig.java
@@ -58,4 +58,12 @@ public interface StorageBlobDevServicesConfig {
      */
     @WithDefault("default-storage-blob")
     String serviceName();
+
+    /**
+     * By default, Azurite will check the request API version is valid API version.
+     * If this property is set to true, the API version check will be skipped, and the request with any API version will be
+     * accepted.
+     */
+    @WithDefault("false")
+    boolean skipApiVersionCheck();
 }


### PR DESCRIPTION
add property added to allow skipping-version-check of azurite. 
This allows using the latest versions of Azure SDKs, for which azurite is sadly not ready yet.

Seems like Azurite is not being updated too soon.

https://github.com/Azure/Azurite/issues/2626
https://github.com/Azure/Azurite/issues/2623

Default for command taken from: https://github.com/Azure/Azurite/blob/main/Dockerfile#L47