### PR TITLE
Release 1.2.3

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "1.2.2"
+  current-version: "1.2.3"
   next-version: "999-SNAPSHOT"
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following matrix shows the compatibility of the extensions with Quarkus vers
 
 | Quarkus Azure services Version | Quarkus Version | Java Version |
 |--------------------------------|------------------|-----------------|
+| [1.2.3](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.3/pom.xml#L12) | [3.31.3](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.3/pom.xml#L20) | [Java 17](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.3/pom.xml#L17-L18) |
 | [1.2.2](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.2/pom.xml#L12) | [3.31.1](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.2/pom.xml#L20) | [Java 17](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.2/pom.xml#L17-L18) |
 | [1.2.1](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.1/pom.xml#L12) | [3.28.4](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.1/pom.xml#L20) | [Java 17](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.1/pom.xml#L17-L18) |
 | [1.2.0](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.0/pom.xml#L12) | [3.26.3](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.0/pom.xml#L20) | [Java 17](https://github.com/quarkiverse/quarkus-azure-services/blob/1.2.0/pom.xml#L17-L18) |

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:project-version: 1.2.2
+:project-version: 1.2.3
 
 :examples-dir: ./../examples/

--- a/integration-tests/azure-app-configuration/README.md
+++ b/integration-tests/azure-app-configuration/README.md
@@ -33,7 +33,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.3`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -41,7 +41,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-cosmos/README.md
+++ b/integration-tests/azure-cosmos/README.md
@@ -33,7 +33,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.3`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -41,7 +41,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-eventhubs/README.md
+++ b/integration-tests/azure-eventhubs/README.md
@@ -33,7 +33,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.3`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -41,7 +41,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-keyvault/README.md
+++ b/integration-tests/azure-keyvault/README.md
@@ -32,7 +32,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.3`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -40,7 +40,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-servicebus-devservices/README.md
+++ b/integration-tests/azure-servicebus-devservices/README.md
@@ -32,7 +32,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
-First, you need to find out the latest release version of the Quarkus Azure services extensions from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
+First, you need to find out the latest release version of the Quarkus Azure services extensions from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.3`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -40,7 +40,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-servicebus/README.md
+++ b/integration-tests/azure-servicebus/README.md
@@ -30,7 +30,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
-First, you need to find out the latest release version of the Quarkus Azure services extensions from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
+First, you need to find out the latest release version of the Quarkus Azure services extensions from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.3`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -38,7 +38,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-services-together/README.md
+++ b/integration-tests/azure-services-together/README.md
@@ -34,7 +34,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.3`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -42,7 +42,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <relativePath></relativePath>
 </parent>
 ```

--- a/integration-tests/azure-storage-blob/README.md
+++ b/integration-tests/azure-storage-blob/README.md
@@ -33,7 +33,7 @@ mvn clean install -DskipTests --file ../../pom.xml
 If you want to use the release version, you need to update the version of dependencies in the `pom.xml` file.
 
 First, you need to find out the latest release version of the Quarkus Azure services extensions
-from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.2`.
+from [releases](https://github.com/quarkiverse/quarkus-azure-services/releases), for example, `1.2.3`.
 
 Then, update the version of dependencies in the `pom.xml` file, for example:
 
@@ -41,7 +41,7 @@ Then, update the version of dependencies in the `pom.xml` file, for example:
 <parent>
     <groupId>io.quarkiverse.azureservices</groupId>
     <artifactId>quarkus-azure-services-parent</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <relativePath></relativePath>
 </parent>
 ```


### PR DESCRIPTION
This pull request updates the project version from `1.2.2` to `1.2.3` throughout the documentation and configuration files. It ensures that all references, examples, and compatibility matrices reflect the new release version.

Version update:

* Bumped the project version to `1.2.3` in the main configuration file `.github/project.yml` and the documentation attributes (`docs/modules/ROOT/pages/includes/attributes.adoc`). [[1]](diffhunk://#diff-735957720c86e5ec3ee129d26dde30a1fd6b7e485100843ef9b576269eb065e9L2-R2) [[2]](diffhunk://#diff-6a9cf7ce7ec74bc87cf4d9b920b636a61915b0ad2683689d9ee8280a1debbf37L1-R1)

Documentation and compatibility updates:

* Updated the compatibility matrix in `README.md` to include version `1.2.3` with its corresponding Quarkus and Java versions.
* Changed all example references and dependency snippets in the integration test `README.md` files to use version `1.2.3` instead of `1.2.2`. This affects the following files:
  - `integration-tests/azure-app-configuration/README.md`
  - `integration-tests/azure-cosmos/README.md`
  - `integration-tests/azure-eventhubs/README.md`
  - `integration-tests/azure-keyvault/README.md`
  - `integration-tests/azure-servicebus-devservices/README.md`
  - `integration-tests/azure-servicebus/README.md`
  - `integration-tests/azure-services-together/README.md`
  - `integration-tests/azure-storage-blob/README.md`