### PR TITLE
Add separate RAG artifact for documentation search

### DIFF
--- a/common/core/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
+++ b/common/core/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
@@ -1,0 +1,2 @@
+groupId=io.quarkiverse.azureservices
+artifactId=quarkus-azure-services-docs-rag

--- a/docs-rag/pom.xml
+++ b/docs-rag/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.azureservices</groupId>
+        <artifactId>quarkus-azure-services-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-azure-services-docs-rag</artifactId>
+    <name>Documentation RAG</name>
+    <description>RAG vector embeddings for documentation</description>
+
+    <properties>
+        <skipRagGeneration>true</skipRagGeneration>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-extension-descriptor</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
+                <version>0.0.7</version>
+                <executions>
+                    <execution>
+                        <id>generate-rag</id>
+                        <goals>
+                            <goal>generate-rag</goal>
+                        </goals>
+                        <configuration>
+                            <guidesDirectory>${project.basedir}/../docs/modules/ROOT/pages</guidesDirectory>
+                            <skip>${skipRagGeneration}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>rag</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
     <module>bom</module>
     <module>services</module>
     <module>common</module>
-  </modules>
+      <module>docs-rag</module>
+    </modules>
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
Ships RAG vector embeddings in a dedicated `docs-rag` module so AI assistants (quarkus-agent-mcp, chappie) can search the extension's documentation (7 pages, 83 chunks, 184K).

- New `docs-rag` module runs the RAG plugin against all documentation pages (activated by `-Prag` or `-Prelease`)
- Pointer file in the deployment JAR tells the loader where to find the RAG artifact
- No deployment JAR size impact

Depends on quarkusio/quarkus-agent-mcp#215 and chappie-bot/chappie-server#43 for the loader-side pointer file support.